### PR TITLE
Add Docker-based OpenFOAM runtime

### DIFF
--- a/flowboost/manager/interfaces/docker_local.py
+++ b/flowboost/manager/interfaces/docker_local.py
@@ -35,14 +35,19 @@ class DockerLocal(Manager):
         get_runtime()._ensure_docker_image()
 
         cmd = [
-            "docker", "run", "-d",
-            "--name", job_name,
-            "-v", f"{submission_cwd}:/work",
-            "-w", "/work",
+            "docker",
+            "run",
+            "-d",
+            "--name",
+            job_name,
+            "-v",
+            f"{submission_cwd}:/work",
+            "-w",
+            "/work",
         ]
         for key, value in script_args.items():
             cmd.extend(["-e", f"{key}={value}"])
-        cmd.extend([self._docker_image, "bash", script.name])
+        cmd.extend([self._docker_image, "bash", f"./{script.name}"])
 
         result = subprocess.run(cmd, stdout=PIPE, stderr=PIPE, text=True)
         if result.returncode != 0:
@@ -55,12 +60,17 @@ class DockerLocal(Manager):
         try:
             result = subprocess.run(
                 ["docker", "stop", "-t", "10", job_id],
-                stdout=PIPE, stderr=PIPE, text=True, timeout=20,
+                stdout=PIPE,
+                stderr=PIPE,
+                text=True,
+                timeout=20,
             )
         except subprocess.TimeoutExpired:
             subprocess.run(
                 ["docker", "kill", job_id],
-                stdout=PIPE, stderr=PIPE, timeout=10,
+                stdout=PIPE,
+                stderr=PIPE,
+                timeout=10,
             )
             result = None
 
@@ -71,7 +81,10 @@ class DockerLocal(Manager):
         try:
             result = subprocess.run(
                 ["docker", "inspect", "--format", "{{.State.Running}}", job_id],
-                stdout=PIPE, stderr=PIPE, text=True, timeout=10,
+                stdout=PIPE,
+                stderr=PIPE,
+                text=True,
+                timeout=10,
             )
         except subprocess.TimeoutExpired:
             return False

--- a/flowboost/manager/interfaces/docker_local.py
+++ b/flowboost/manager/interfaces/docker_local.py
@@ -1,12 +1,11 @@
 import logging
-import os
 import subprocess
 from pathlib import Path
 from subprocess import PIPE
 from typing import Any, Optional
 
 from flowboost.manager.manager import Manager
-from flowboost.openfoam.runtime import DOCKER_IMAGE, FOAMRuntime, get_runtime
+from flowboost.openfoam.runtime import FOAMRuntime, docker_image_name, get_runtime
 
 
 class DockerLocal(Manager):
@@ -18,7 +17,7 @@ class DockerLocal(Manager):
     """
 
     def __init__(self, wdir: Path | str, job_limit: int = 1) -> None:
-        self._docker_image = os.environ.get("FLOWBOOST_FOAM_IMAGE", DOCKER_IMAGE)
+        self._docker_image = docker_image_name()
         super().__init__(wdir, job_limit)
 
     @staticmethod

--- a/flowboost/manager/interfaces/docker_local.py
+++ b/flowboost/manager/interfaces/docker_local.py
@@ -1,0 +1,87 @@
+import logging
+import os
+import subprocess
+from pathlib import Path
+from subprocess import PIPE
+from typing import Any, Optional
+
+from flowboost.manager.manager import Manager
+from flowboost.openfoam.runtime import DOCKER_IMAGE, FOAMRuntime, get_runtime
+
+
+class DockerLocal(Manager):
+    """Run OpenFOAM simulations in per-job Docker containers.
+
+    Each submitted case gets its own detached container. The case directory
+    is bind-mounted into the container so simulation output appears directly
+    on the host filesystem.
+    """
+
+    def __init__(self, wdir: Path | str, job_limit: int = 1) -> None:
+        self._docker_image = os.environ.get("FLOWBOOST_FOAM_IMAGE", DOCKER_IMAGE)
+        super().__init__(wdir, job_limit)
+
+    @staticmethod
+    def _is_available() -> bool:
+        return FOAMRuntime._docker_available()
+
+    def _submit_job(
+        self,
+        job_name: str,
+        submission_cwd: Path,
+        script: Path,
+        script_args: dict[str, Any] = {},
+    ) -> Optional[str]:
+        get_runtime()._ensure_docker_image()
+
+        cmd = [
+            "docker", "run", "-d",
+            "--name", job_name,
+            "-v", f"{submission_cwd}:/work",
+            "-w", "/work",
+        ]
+        for key, value in script_args.items():
+            cmd.extend(["-e", f"{key}={value}"])
+        cmd.extend([self._docker_image, "bash", script.name])
+
+        result = subprocess.run(cmd, stdout=PIPE, stderr=PIPE, text=True)
+        if result.returncode != 0:
+            logging.error(f"Docker run failed: {result.stderr}")
+            return None
+
+        return result.stdout.strip()
+
+    def _cancel_job(self, job_id: str) -> bool:
+        try:
+            result = subprocess.run(
+                ["docker", "stop", "-t", "10", job_id],
+                stdout=PIPE, stderr=PIPE, text=True, timeout=20,
+            )
+        except subprocess.TimeoutExpired:
+            subprocess.run(
+                ["docker", "kill", job_id],
+                stdout=PIPE, stderr=PIPE, timeout=10,
+            )
+            result = None
+
+        subprocess.run(["docker", "rm", job_id], stdout=PIPE, stderr=PIPE, timeout=10)
+        return result is not None and result.returncode == 0
+
+    def _job_has_finished(self, job_id: str) -> bool:
+        try:
+            result = subprocess.run(
+                ["docker", "inspect", "--format", "{{.State.Running}}", job_id],
+                stdout=PIPE, stderr=PIPE, text=True, timeout=10,
+            )
+        except subprocess.TimeoutExpired:
+            return False
+
+        if result.returncode != 0:
+            return True  # Container gone = finished
+
+        if result.stdout.strip() == "true":
+            return False
+
+        # Container stopped — clean it up
+        subprocess.run(["docker", "rm", job_id], stdout=PIPE, stderr=PIPE, timeout=10)
+        return True

--- a/flowboost/manager/interfaces/docker_local.py
+++ b/flowboost/manager/interfaces/docker_local.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import subprocess
 from pathlib import Path
 from subprocess import PIPE
@@ -39,11 +40,18 @@ class DockerLocal(Manager):
             "-d",
             "--name",
             job_name,
-            "-v",
-            f"{submission_cwd}:/work",
-            "-w",
-            "/work",
         ]
+        # Run as host user so bind-mounted files aren't owned by root
+        if os.name != "nt":
+            cmd.extend(["--user", f"{os.getuid()}:{os.getgid()}"])
+        cmd.extend(
+            [
+                "-v",
+                f"{submission_cwd}:/work",
+                "-w",
+                "/work",
+            ]
+        )
         for key, value in script_args.items():
             cmd.extend(["-e", f"{key}={value}"])
         cmd.extend([self._docker_image, "bash", f"./{script.name}"])

--- a/flowboost/manager/manager.py
+++ b/flowboost/manager/manager.py
@@ -11,7 +11,7 @@ from typing import Any, Optional
 from flowboost.openfoam.case import Case, Status
 from flowboost.utilities.time import td_format
 
-SUPPORTED_SCHEDULERS = ("Local", "SGE", "Slurm")
+SUPPORTED_SCHEDULERS = ("Local", "SGE", "Slurm", "DockerLocal")
 
 
 class Manager(ABC):
@@ -136,6 +136,7 @@ class Manager(ABC):
         Returns:
             Manager: A job manager implementing `Manager` interface
         """
+        from flowboost.manager.interfaces.docker_local import DockerLocal
         from flowboost.manager.interfaces.local import Local
         from flowboost.manager.interfaces.sge import SGE
         from flowboost.manager.interfaces.slurm import Slurm
@@ -147,6 +148,8 @@ class Manager(ABC):
                 manager = SGE(wdir=wdir, job_limit=job_limit)
             case "slurm":
                 manager = Slurm(wdir=wdir, job_limit=job_limit)
+            case "dockerlocal":
+                manager = DockerLocal(wdir=wdir, job_limit=job_limit)
             case _:
                 raise NotImplementedError(
                     f"Scheduler '{scheduler}' not in {SUPPORTED_SCHEDULERS}"

--- a/flowboost/openfoam/case.py
+++ b/flowboost/openfoam/case.py
@@ -118,7 +118,7 @@ class Case:
         Returns:
             Case: Object representing the new case
         """
-        new_case_path = Path(clone_to)
+        new_case_path = Path(clone_to).resolve()
         if new_case_path.exists():
             raise FileExistsError(f"Case directory already exists: '{new_case_path}'")
 
@@ -228,7 +228,7 @@ class Case:
         # Get path
         tutorial_path = FOAM.tutorial(relative_path=tutorial)
 
-        new_case_dir = Path(new_case_dir)
+        new_case_dir = Path(new_case_dir).resolve()
         if new_case_dir.exists():
             logging.warning(
                 f"Directory already exists: returning existing Case [{new_case_dir}]"

--- a/flowboost/openfoam/case.py
+++ b/flowboost/openfoam/case.py
@@ -14,7 +14,7 @@ import tomlkit
 from flowboost.openfoam.data import Data
 from flowboost.openfoam.dictionary import DictionaryLink, DictionaryReader, Entry
 from flowboost.openfoam.interface import FOAM, run_command
-from flowboost.openfoam.runtime import FoamRuntime, get_runtime
+from flowboost.openfoam.runtime import FOAMRuntime, get_runtime
 from flowboost.optimizer.search_space import Dimension
 
 if TYPE_CHECKING:
@@ -237,7 +237,7 @@ class Case:
 
         if method == "copy":
             runtime = get_runtime()
-            if runtime.mode != FoamRuntime.Mode.NATIVE:
+            if runtime.mode != FOAMRuntime.Mode.NATIVE:
                 raise ValueError(
                     "method='copy' is not supported in Docker mode — use method='foamCloneCase'"
                 )

--- a/flowboost/openfoam/case.py
+++ b/flowboost/openfoam/case.py
@@ -14,6 +14,7 @@ import tomlkit
 from flowboost.openfoam.data import Data
 from flowboost.openfoam.dictionary import DictionaryLink, DictionaryReader, Entry
 from flowboost.openfoam.interface import FOAM, run_command
+from flowboost.openfoam.runtime import FoamRuntime, get_runtime
 from flowboost.optimizer.search_space import Dimension
 
 if TYPE_CHECKING:
@@ -235,6 +236,11 @@ class Case:
             return Case(path=new_case_dir)
 
         if method == "copy":
+            runtime = get_runtime()
+            if runtime.mode != FoamRuntime.Mode.NATIVE:
+                raise ValueError(
+                    "method='copy' is not supported in Docker mode — use method='foamCloneCase'"
+                )
             shutil.copytree(str(tutorial_path), str(new_case_dir))
         elif method == "foamCloneCase":
             cmd = ["foamCloneCase", tutorial_path, new_case_dir]

--- a/flowboost/openfoam/case.py
+++ b/flowboost/openfoam/case.py
@@ -1,6 +1,8 @@
 from __future__ import annotations  # pre-3.11 compatibility
 
 import logging
+import os
+import stat
 from datetime import datetime, timezone
 from enum import Enum
 from hashlib import blake2b
@@ -177,7 +179,9 @@ class Case:
         dest_path = Path(destination).resolve().absolute()
 
         if not source_path.exists():
-            raise FileNotFoundError(f"Source case directory does not exist: {source_path}")
+            raise FileNotFoundError(
+                f"Source case directory does not exist: {source_path}"
+            )
 
         if dest_path.exists():
             raise FileExistsError(f"Destination directory already exists: {dest_path}")
@@ -363,7 +367,9 @@ class Case:
 
         # Try to read from metadata first (for completed cases)
         metadata = self.read_metadata()
-        optimizer_suggestions = metadata.get("optimizer-suggestion", {}) if metadata else {}
+        optimizer_suggestions = (
+            metadata.get("optimizer-suggestion", {}) if metadata else {}
+        )
 
         for dim in dimensions:
             # First try to get from saved optimizer-suggestion metadata
@@ -413,7 +419,9 @@ class Case:
 
         return output_mapping
 
-    def submission_script(self, glob_with: str = "Allrun*", script_name: Optional[str] = None) -> Optional[Path]:
+    def submission_script(
+        self, glob_with: str = "Allrun*", script_name: Optional[str] = None
+    ) -> Optional[Path]:
         """Finds a submission script in the case directory.
 
         Args:
@@ -611,6 +619,16 @@ class Case:
 
         return cls(case_dir)
 
+    @staticmethod
+    def _force_rmtree(path: Path):
+        """Remove a directory tree, handling root-owned files from Docker."""
+
+        def _on_error(func, fpath, _exc_info):
+            os.chmod(fpath, stat.S_IRWXU)
+            func(fpath)
+
+        shutil.rmtree(path, onerror=_on_error)
+
     def _delete_all_data(self, skip_familiarity_checks: bool = False):
         """ Permanently deletes a case directory and all its contents.
 
@@ -624,7 +642,7 @@ class Case:
         # Verify that the directory looks like an OpenFOAM case directory
         if path_is_foam_dir(self.path) or skip_familiarity_checks:
             logging.info(f"Deleting case directory: {str(self)}")
-            run_command(command=["rm", "-rf", self.path])
+            self._force_rmtree(self.path)
             return True
 
         logging.error(

--- a/flowboost/openfoam/dictionary.py
+++ b/flowboost/openfoam/dictionary.py
@@ -1,10 +1,10 @@
 import json
 import logging
-import subprocess
 from functools import total_ordering
 from pathlib import Path
 from typing import Any, Optional, Union
 
+from flowboost.openfoam.interface import run_foam_command
 from flowboost.openfoam.types import FOAMType
 
 
@@ -123,7 +123,7 @@ class DictionaryReader(Dictionary):
                 raise ValueError(f"No such entry in {self}: {entry}")
             entry = read
 
-        if not entry or not isinstance(entry, "Entry"):
+        if not entry or not isinstance(entry, Entry):
             raise ValueError(f"No such entry in {self}: {entry}")
 
         return entry.set(new_value=new_value)
@@ -186,10 +186,8 @@ class DictionaryReader(Dictionary):
         # Execute the CLI command to add the entry with the specified value
         foam_value = FOAMType.to_FOAM(value)
         cmd = ["foamDictionary", self.path, "-entry", entry_path, "-add", foam_value]
-        result = subprocess.run(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
-        )
-        if result.stderr:
+        result = run_foam_command(cmd)
+        if result.returncode != 0:
             logging.error(f"Error adding new entry '{entry_path}': {result.stderr}")
             return None
 
@@ -243,10 +241,8 @@ class DictionaryReader(Dictionary):
 
         cmd = ["foamDictionary", self.path, "-keywords"]
 
-        result = subprocess.run(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
-        )
-        if result.stderr:
+        result = run_foam_command(cmd)
+        if result.returncode != 0:
             logging.error(f"Error discovering top-level keywords: {result.stderr}")
             return
 
@@ -360,14 +356,14 @@ class Entry:
     @property
     def name(self) -> Optional[str]:
         """Lazy-loads and returns name for dimensioned entries."""
-        if self.raw_value is None and self.terminating:
+        if self.raw_value is None and self.terminating is not False:
             self._discover_value()
 
         return self._name
 
     @property
     def dimension(self) -> Optional[str]:
-        if self.raw_value is None and self.terminating:
+        if self.raw_value is None and self.terminating is not False:
             self._discover_value()
 
         # Dimension is set during value discovery
@@ -376,7 +372,7 @@ class Entry:
     @property
     def value(self):
         """Lazy-loads and returns the post-processed, Pythonic value of the entry."""
-        if self._value is None and self.terminating:
+        if self._value is None and self.terminating is not False:
             self._discover_value()
 
         return self._value
@@ -384,7 +380,7 @@ class Entry:
     @property
     def raw_value(self):
         """Returns the raw string value of the entry."""
-        if self._raw_value is None and self.terminating:
+        if self._raw_value is None and self.terminating is not False:
             self._discover_value()
 
         return self._raw_value
@@ -480,11 +476,9 @@ class Entry:
             "-set",
             new_raw_val,
         ]
-        result = subprocess.run(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
-        )
+        result = run_foam_command(cmd)
 
-        if result.returncode != 0 or result.stderr:
+        if result.returncode != 0:
             logging.error(
                 f"Error setting value for '{self.print_path()}': {result.stderr}"
             )
@@ -521,11 +515,6 @@ class Entry:
 
     def delete(self) -> bool:
         """Deletes this entry from the dictionary."""
-        if self.parent:
-            # Remove this entry from the parent's keywords list
-            if self.parent.keywords and self in self.parent.keywords:
-                self.parent.keywords.remove(self)
-
         # Execute the CLI command to remove the entry from the dictionary file
         cmd = [
             "foamDictionary",
@@ -534,15 +523,21 @@ class Entry:
             self.print_path(),
             "-remove",
         ]
-        result = subprocess.run(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
-        )
+        result = run_foam_command(cmd)
 
-        if result.stderr:
+        if result.returncode != 0:
             logging.error(
                 f"Error deleting entry '{self.print_path()}': {result.stderr}"
             )
             return False
+
+        # Remove from in-memory list only after CLI success
+        if self.parent:
+            if self.parent.keywords and self in self.parent.keywords:
+                self.parent.keywords.remove(self)
+        else:
+            if self.dictionary._keywords and self in self.dictionary._keywords:
+                self.dictionary._keywords.remove(self)
 
         self._value = None
         self._raw_value = None
@@ -583,10 +578,11 @@ class Entry:
                 "-entry",
                 self.print_path(),
             ]
-            result = subprocess.run(
-                cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
-            )
-            if result.stderr:
+            result = run_foam_command(cmd)
+            # Note: stderr check is intentional here (unlike other call sites).
+            # foamDictionary -keywords writes to stderr for leaf entries even
+            # with returncode 0 — stderr presence signals a terminating entry.
+            if result.returncode != 0 or result.stderr:
                 self.terminating = True
                 return
 
@@ -613,11 +609,9 @@ class Entry:
             self.print_path(),
             "-value",
         ]
-        result = subprocess.run(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
-        )
+        result = run_foam_command(cmd)
 
-        if result.stderr:
+        if result.returncode != 0:
             self._value, self._raw_value = None, None
             if self._verbose:
                 logging.error(

--- a/flowboost/openfoam/docker/Dockerfile
+++ b/flowboost/openfoam/docker/Dockerfile
@@ -1,0 +1,23 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        wget \
+        software-properties-common \
+        ca-certificates && \
+    wget -q -O /etc/apt/trusted.gpg.d/openfoam.asc https://dl.openfoam.org/gpg.key && \
+    add-apt-repository -y http://dl.openfoam.org/ubuntu && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends openfoam13 file && \
+    apt-get purge -y wget software-properties-common && \
+    apt-get autoremove -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Source OpenFOAM environment by default
+RUN echo "source /opt/openfoam13/etc/bashrc" >> /etc/bash.bashrc
+ENV BASH_ENV=/opt/openfoam13/etc/bashrc
+
+WORKDIR /work

--- a/flowboost/openfoam/interface.py
+++ b/flowboost/openfoam/interface.py
@@ -4,6 +4,8 @@ import subprocess
 from pathlib import Path
 from typing import Any, Optional
 
+from flowboost.openfoam.runtime import FoamRuntime, get_runtime
+
 
 def openfoam_in_env(func):
     def wrapper(*args, **kwargs):
@@ -17,6 +19,9 @@ def openfoam_in_env(func):
 class FOAM:
     @staticmethod
     def source(path: str):
+        if get_runtime().mode != FoamRuntime.Mode.NATIVE:
+            return  # Container has its own environment
+
         command = f"source {path} && env"
         proc = subprocess.Popen(
             command, stdout=subprocess.PIPE, shell=True, executable="/bin/bash"
@@ -31,7 +36,11 @@ class FOAM:
 
     @staticmethod
     @openfoam_in_env
-    def tutorials() -> Path:
+    def tutorials() -> str | Path:
+        runtime = get_runtime()
+        if runtime.mode != FoamRuntime.Mode.NATIVE:
+            return runtime.foam_tutorials_path()
+
         tutorials_path = os.environ.get("FOAM_TUTORIALS")
         if not tutorials_path:
             raise FileNotFoundError(f"OpenFOAM tutorials not found in {tutorials_path}")
@@ -42,12 +51,24 @@ class FOAM:
         if os.getenv(env_var):
             return True
 
-        return False
+        # Check if Docker runtime is available and usable
+        try:
+            runtime = get_runtime()
+            return runtime.is_available()
+        except RuntimeError:
+            return False
 
     @staticmethod
     @openfoam_in_env
-    def tutorial(relative_path: str) -> Path:
-        tutorial_case = FOAM.tutorials() / relative_path
+    def tutorial(relative_path: str) -> str | Path:
+        tutorials = FOAM.tutorials()
+        runtime = get_runtime()
+
+        if runtime.mode != FoamRuntime.Mode.NATIVE:
+            # tutorials is a container-internal path string
+            return f"{tutorials}/{relative_path}"
+
+        tutorial_case = Path(tutorials) / relative_path
         if not tutorial_case.exists():
             raise FileNotFoundError(
                 f"Tutorial case path does not exist: '{tutorial_case}'"
@@ -57,27 +78,34 @@ class FOAM:
 
 
 def run_command(command: list[Any], cwd: Optional[Path] = None) -> str:
-    """ Executes a shell command in a given directory, returning the utf-8 decoded
-    output.
+    """Executes a shell command, returning stdout. Routes FOAM commands
+    through the runtime (native or Docker).
 
     Args:
         command (list[Any]): List of command arguments
-        cwd (Optional[Path], optional): Directory to run command in, if not current \
-            directory. Defaults to None.
+        cwd (Optional[Path]): Directory to run command in. Defaults to None.
 
     Raises:
-        ValueError: _description_
+        ValueError: On non-zero return code.
 
     Returns:
-        str: utf-8 decoded command output from stdout
+        str: Command stdout
     """
     logging.debug(f"Executing command: {command}")
-    result = subprocess.run(
-        command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=cwd, text=True
-    )
+    result = get_runtime().run(command, cwd=cwd)
 
-    if result.stderr:
-        raise ValueError(f"Error executing command '{command}': {result.stderr}")
+    if result.returncode != 0:
+        raise ValueError(
+            f"Command '{command}' failed (rc={result.returncode}): {result.stderr}"
+        )
 
     logging.debug(f"Command output: {result.stdout}")
     return result.stdout
+
+
+def run_foam_command(
+    command: list, cwd: Path | None = None
+) -> subprocess.CompletedProcess:
+    """Execute a command through the runtime, returning CompletedProcess
+    for caller-side error handling."""
+    return get_runtime().run(command, cwd=cwd)

--- a/flowboost/openfoam/interface.py
+++ b/flowboost/openfoam/interface.py
@@ -4,7 +4,7 @@ import subprocess
 from pathlib import Path
 from typing import Any, Optional
 
-from flowboost.openfoam.runtime import FoamRuntime, get_runtime
+from flowboost.openfoam.runtime import FOAMRuntime, get_runtime
 
 
 def openfoam_in_env(func):
@@ -19,7 +19,7 @@ def openfoam_in_env(func):
 class FOAM:
     @staticmethod
     def source(path: str):
-        if get_runtime().mode != FoamRuntime.Mode.NATIVE:
+        if get_runtime().mode != FOAMRuntime.Mode.NATIVE:
             return  # Container has its own environment
 
         command = f"source {path} && env"
@@ -38,7 +38,7 @@ class FOAM:
     @openfoam_in_env
     def tutorials() -> str | Path:
         runtime = get_runtime()
-        if runtime.mode != FoamRuntime.Mode.NATIVE:
+        if runtime.mode != FOAMRuntime.Mode.NATIVE:
             return runtime._foam_tutorials_path()
 
         tutorials_path = os.environ.get("FOAM_TUTORIALS")
@@ -64,7 +64,7 @@ class FOAM:
         tutorials = FOAM.tutorials()
         runtime = get_runtime()
 
-        if runtime.mode != FoamRuntime.Mode.NATIVE:
+        if runtime.mode != FOAMRuntime.Mode.NATIVE:
             # tutorials is a container-internal path string
             return f"{tutorials}/{relative_path}"
 

--- a/flowboost/openfoam/interface.py
+++ b/flowboost/openfoam/interface.py
@@ -39,7 +39,7 @@ class FOAM:
     def tutorials() -> str | Path:
         runtime = get_runtime()
         if runtime.mode != FoamRuntime.Mode.NATIVE:
-            return runtime.foam_tutorials_path()
+            return runtime._foam_tutorials_path()
 
         tutorials_path = os.environ.get("FOAM_TUTORIALS")
         if not tutorials_path:

--- a/flowboost/openfoam/runtime.py
+++ b/flowboost/openfoam/runtime.py
@@ -237,14 +237,14 @@ class FoamRuntime:
     # OpenFOAM environment queries
     # ------------------------------------------------------------------
 
-    def foam_tutorials_path(self) -> str:
+    def _foam_tutorials_path(self) -> str:
         """Query the container for $FOAM_TUTORIALS. Returns a container-internal path.
 
         Only valid in Docker mode. Native mode should read FOAM_TUTORIALS
         from the environment directly (handled by FOAM.tutorials()).
         """
         assert self.mode != FoamRuntime.Mode.NATIVE, \
-            "foam_tutorials_path() should not be called in native mode"
+            "_foam_tutorials_path() should not be called in native mode"
 
         if self._cached_foam_tutorials:
             return self._cached_foam_tutorials

--- a/flowboost/openfoam/runtime.py
+++ b/flowboost/openfoam/runtime.py
@@ -148,6 +148,9 @@ class FOAMRuntime:
         self._ensure_docker_image()
 
         create_cmd = ["docker", "create", "--rm", "-i"]
+        # Run as host user so bind-mounted files aren't owned by root
+        if os.name != "nt":
+            create_cmd.extend(["--user", f"{os.getuid()}:{os.getgid()}"])
         for host_root, container_root in self._mounts:
             create_cmd.extend(["-v", f"{host_root}:{container_root}"])
         create_cmd.extend([self._docker_image, "sleep", "infinity"])
@@ -169,9 +172,7 @@ class FOAMRuntime:
         )
         if result.returncode != 0:
             # Clean up the created-but-not-started container
-            subprocess.run(
-                ["docker", "rm", cid], stdout=PIPE, stderr=PIPE, timeout=10
-            )
+            subprocess.run(["docker", "rm", cid], stdout=PIPE, stderr=PIPE, timeout=10)
             raise RuntimeError(f"Failed to start container: {result.stderr}")
 
         self._container_id = cid

--- a/flowboost/openfoam/runtime.py
+++ b/flowboost/openfoam/runtime.py
@@ -13,6 +13,11 @@ DOCKER_IMAGE = "flowboost/openfoam:13"
 DOCKERFILE_DIR = Path(__file__).resolve().parent / "docker"
 
 
+def docker_image_name() -> str:
+    """Return the configured Docker image name (respects FLOWBOOST_FOAM_IMAGE)."""
+    return os.environ.get("FLOWBOOST_FOAM_IMAGE", DOCKER_IMAGE)
+
+
 class FOAMRuntime:
     """Decides how to execute OpenFOAM CLI commands: natively or via Docker.
 
@@ -35,10 +40,12 @@ class FOAMRuntime:
     }
 
     def __init__(self):
-        self._docker_image = os.environ.get("FLOWBOOST_FOAM_IMAGE", DOCKER_IMAGE)
+        self._docker_image = docker_image_name()
         self._cached_foam_tutorials: str | None = None
         self._mounts: list[tuple[Path, str]] = []
         self._container_id: str | None = None
+        self._atexit_registered: bool = False
+        self._in_container_block: bool = False
         self.mode = self._detect_mode()
 
     def _detect_mode(self) -> "FOAMRuntime.Mode":
@@ -145,27 +152,37 @@ class FOAMRuntime:
             create_cmd.extend(["-v", f"{host_root}:{container_root}"])
         create_cmd.extend([self._docker_image, "sleep", "infinity"])
 
-        result = subprocess.run(create_cmd, stdout=PIPE, stderr=PIPE, text=True)
+        result = subprocess.run(
+            create_cmd, stdout=PIPE, stderr=PIPE, text=True, timeout=30
+        )
         if result.returncode != 0:
             raise RuntimeError(f"Failed to create container: {result.stderr}")
 
-        self._container_id = result.stdout.strip()
+        cid = result.stdout.strip()
 
         result = subprocess.run(
-            ["docker", "start", self._container_id],
+            ["docker", "start", cid],
             stdout=PIPE,
             stderr=PIPE,
             text=True,
+            timeout=10,
         )
         if result.returncode != 0:
-            self._container_id = None
+            # Clean up the created-but-not-started container
+            subprocess.run(
+                ["docker", "rm", cid], stdout=PIPE, stderr=PIPE, timeout=10
+            )
             raise RuntimeError(f"Failed to start container: {result.stderr}")
 
-        logging.debug(f"Started persistent container {self._container_id[:12]}")
-        atexit.register(self._stop_container)
+        self._container_id = cid
+        logging.debug(f"Started persistent container {cid[:12]}")
+
+        if not self._atexit_registered:
+            atexit.register(self._stop_container)
+            self._atexit_registered = True
 
     def _stop_container(self):
-        """Stop and remove the persistent container."""
+        """Stop and remove the persistent container. Never raises."""
         if not self._container_id:
             return
 
@@ -180,13 +197,17 @@ class FOAMRuntime:
                 timeout=15,
             )
         except subprocess.TimeoutExpired:
-            # Force-kill if graceful stop hangs
-            subprocess.run(
-                ["docker", "kill", cid],
-                stdout=PIPE,
-                stderr=PIPE,
-                timeout=10,
-            )
+            try:
+                subprocess.run(
+                    ["docker", "kill", cid],
+                    stdout=PIPE,
+                    stderr=PIPE,
+                    timeout=10,
+                )
+            except (subprocess.TimeoutExpired, OSError):
+                logging.warning(f"Failed to kill container {cid[:12]}")
+        except OSError:
+            logging.warning(f"Failed to stop container {cid[:12]}")
 
         logging.debug(f"Stopped container {cid[:12]}")
 
@@ -205,6 +226,12 @@ class FOAMRuntime:
                 "Cannot add mounts after the container has started. "
                 "Call add_mount() before running any FOAM commands."
             )
+        existing_guests = {g for _, g in self._mounts}
+        if guest_path in existing_guests:
+            raise RuntimeError(
+                f"Mount guest path '{guest_path}' is already in use. "
+                "Use a different guest_path to avoid shadowing."
+            )
         self._mounts.append((host_path.resolve(), guest_path))
 
     def _auto_mount(self, command: list, cwd: Path | None):
@@ -219,7 +246,7 @@ class FOAMRuntime:
             host_dirs.append(Path(cwd).resolve())
         for arg in command[1:]:
             p = Path(arg)
-            if p.is_absolute() and not str(arg).startswith("/opt"):
+            if p.is_absolute() and (p.exists() or p.parent.exists()):
                 # Use parent dir — the arg may be a file or non-existent target
                 host_dirs.append(p.resolve().parent)
 
@@ -233,6 +260,13 @@ class FOAMRuntime:
         for p in uncovered[1:]:
             while not p.is_relative_to(common):
                 common = common.parent
+
+        if len(common.parts) <= 2:
+            raise RuntimeError(
+                f"Auto-mount would mount '{common}' which is too broad. "
+                f"Pre-register mounts with container() or add_mount() instead. "
+                f"Uncovered paths: {uncovered}"
+            )
 
         mount_index = len(self._mounts)
         guest_path = f"/work{mount_index}" if mount_index > 0 else "/work"
@@ -253,19 +287,31 @@ class FOAMRuntime:
     def container(self, *mounts: Path):
         """Context manager that runs a Docker container for the block's duration.
 
+        Not re-entrant — if a container is already running via ``container()``,
+        inner functions should just call ``run()`` directly.
+
         Args:
             *mounts: Host directories to bind-mount. Pre-registering a parent
                 directory (e.g. the workdir) avoids container restarts when
                 iterating over subdirectories.
         """
+        if self._in_container_block:
+            raise RuntimeError(
+                "container() is not re-entrant — a container is already running. "
+                "Inner functions should use run() directly."
+            )
         prev_mounts = self._mounts.copy()
         for m in mounts:
-            self.add_mount(m)
+            mount_index = len(self._mounts)
+            guest = f"/work{mount_index}" if mount_index > 0 else "/work"
+            self.add_mount(m, guest)
         if self.mode == FOAMRuntime.Mode.DOCKER:
             self._ensure_container()
+        self._in_container_block = True
         try:
             yield self
         finally:
+            self._in_container_block = False
             self._stop_container()
             self._mounts = prev_mounts
 
@@ -322,9 +368,10 @@ class FOAMRuntime:
         Only valid in Docker mode. Native mode should read FOAM_TUTORIALS
         from the environment directly (handled by FOAM.tutorials()).
         """
-        assert self.mode != FOAMRuntime.Mode.NATIVE, (
-            "_foam_tutorials_path() should not be called in native mode"
-        )
+        if self.mode == FOAMRuntime.Mode.NATIVE:
+            raise RuntimeError(
+                "_foam_tutorials_path() should not be called in native mode"
+            )
 
         if self._cached_foam_tutorials:
             return self._cached_foam_tutorials

--- a/flowboost/openfoam/runtime.py
+++ b/flowboost/openfoam/runtime.py
@@ -12,7 +12,7 @@ DOCKER_IMAGE = "flowboost/openfoam:13"
 DOCKERFILE_DIR = Path(__file__).resolve().parent / "docker"
 
 
-class FoamRuntime:
+class FOAMRuntime:
     """Decides how to execute OpenFOAM CLI commands: natively or via Docker.
 
     In Docker mode, a single persistent container is started on first use
@@ -39,24 +39,24 @@ class FoamRuntime:
         self._container_id: str | None = None
         self.mode = self._detect_mode()
 
-    def _detect_mode(self) -> "FoamRuntime.Mode":
+    def _detect_mode(self) -> "FOAMRuntime.Mode":
         forced = os.environ.get("FLOWBOOST_FOAM_MODE", "auto")
 
         if forced == "native":
-            return FoamRuntime.Mode.NATIVE
+            return FOAMRuntime.Mode.NATIVE
         if forced == "docker":
             if not self._docker_available():
                 raise RuntimeError(
                     "FLOWBOOST_FOAM_MODE=docker but Docker is not available"
                 )
-            return FoamRuntime.Mode.DOCKER
+            return FOAMRuntime.Mode.DOCKER
 
         # Auto-detect: native → docker → error
         if os.environ.get("FOAM_INST_DIR"):
-            return FoamRuntime.Mode.NATIVE
+            return FOAMRuntime.Mode.NATIVE
 
         if self._docker_available():
-            return FoamRuntime.Mode.DOCKER
+            return FOAMRuntime.Mode.DOCKER
 
         raise RuntimeError(
             "OpenFOAM not available: no native install (FOAM_INST_DIR unset) "
@@ -116,9 +116,9 @@ class FoamRuntime:
 
     def is_available(self) -> bool:
         """Check if this runtime can actually execute FOAM commands."""
-        if self.mode == FoamRuntime.Mode.NATIVE:
+        if self.mode == FOAMRuntime.Mode.NATIVE:
             return True
-        if self.mode == FoamRuntime.Mode.DOCKER:
+        if self.mode == FOAMRuntime.Mode.DOCKER:
             # Available if image exists or can be built
             return self._docker_image_available() or DOCKERFILE_DIR.is_dir()
         return False
@@ -209,7 +209,7 @@ class FoamRuntime:
         """Execute a command, routing FOAM commands through Docker if needed."""
         cmd_name = Path(command[0]).name if command else ""
 
-        if self.mode == FoamRuntime.Mode.NATIVE or cmd_name not in self.FOAM_COMMANDS:
+        if self.mode == FOAMRuntime.Mode.NATIVE or cmd_name not in self.FOAM_COMMANDS:
             return subprocess.run(command, stdout=PIPE, stderr=PIPE, cwd=cwd, text=True)
 
         return self._docker_exec(command, cwd)
@@ -243,7 +243,7 @@ class FoamRuntime:
         Only valid in Docker mode. Native mode should read FOAM_TUTORIALS
         from the environment directly (handled by FOAM.tutorials()).
         """
-        assert self.mode != FoamRuntime.Mode.NATIVE, \
+        assert self.mode != FOAMRuntime.Mode.NATIVE, \
             "_foam_tutorials_path() should not be called in native mode"
 
         if self._cached_foam_tutorials:
@@ -271,7 +271,7 @@ class FoamRuntime:
 
     def transfer_file(self, remote_path: str, local_path: Path):
         """Copy a file from the container to the host."""
-        if self.mode == FoamRuntime.Mode.NATIVE:
+        if self.mode == FOAMRuntime.Mode.NATIVE:
             shutil.copy2(remote_path, local_path)
             return
 
@@ -324,13 +324,13 @@ class FoamRuntime:
 
 
 
-_runtime: FoamRuntime | None = None
+_runtime: FOAMRuntime | None = None
 
 
-def get_runtime() -> FoamRuntime:
+def get_runtime() -> FOAMRuntime:
     global _runtime
     if _runtime is None:
-        _runtime = FoamRuntime()
+        _runtime = FOAMRuntime()
     return _runtime
 
 

--- a/flowboost/openfoam/runtime.py
+++ b/flowboost/openfoam/runtime.py
@@ -4,6 +4,7 @@ import os
 import shlex
 import shutil
 import subprocess
+from contextlib import contextmanager
 from enum import Enum
 from pathlib import Path
 from subprocess import PIPE
@@ -71,7 +72,10 @@ class FOAMRuntime:
     def _docker_available() -> bool:
         try:
             result = subprocess.run(
-                ["docker", "info"], stdout=PIPE, stderr=PIPE, timeout=5,
+                ["docker", "info"],
+                stdout=PIPE,
+                stderr=PIPE,
+                timeout=5,
             )
             return result.returncode == 0
         except (FileNotFoundError, subprocess.TimeoutExpired):
@@ -82,7 +86,9 @@ class FOAMRuntime:
         try:
             result = subprocess.run(
                 ["docker", "image", "inspect", self._docker_image],
-                stdout=PIPE, stderr=PIPE, timeout=5,
+                stdout=PIPE,
+                stderr=PIPE,
+                timeout=5,
             )
             return result.returncode == 0
         except (FileNotFoundError, subprocess.TimeoutExpired):
@@ -105,13 +111,12 @@ class FOAMRuntime:
         )
         result = subprocess.run(
             ["docker", "build", "-t", self._docker_image, str(DOCKERFILE_DIR)],
-            stderr=PIPE, text=True,
+            stderr=PIPE,
+            text=True,
             timeout=600,
         )
         if result.returncode != 0:
-            raise RuntimeError(
-                f"Failed to build Docker image: {result.stderr}"
-            )
+            raise RuntimeError(f"Failed to build Docker image: {result.stderr}")
         logging.info(f"Docker image '{self._docker_image}' built successfully")
 
     def is_available(self) -> bool:
@@ -147,7 +152,9 @@ class FOAMRuntime:
 
         result = subprocess.run(
             ["docker", "start", self._container_id],
-            stdout=PIPE, stderr=PIPE, text=True,
+            stdout=PIPE,
+            stderr=PIPE,
+            text=True,
         )
         if result.returncode != 0:
             self._container_id = None
@@ -167,13 +174,17 @@ class FOAMRuntime:
         try:
             subprocess.run(
                 ["docker", "stop", "-t", "5", cid],
-                stdout=PIPE, stderr=PIPE, timeout=15,
+                stdout=PIPE,
+                stderr=PIPE,
+                timeout=15,
             )
         except subprocess.TimeoutExpired:
             # Force-kill if graceful stop hangs
             subprocess.run(
                 ["docker", "kill", cid],
-                stdout=PIPE, stderr=PIPE, timeout=10,
+                stdout=PIPE,
+                stderr=PIPE,
+                timeout=10,
             )
 
         logging.debug(f"Stopped container {cid[:12]}")
@@ -194,6 +205,66 @@ class FOAMRuntime:
                 "Call add_mount() before running any FOAM commands."
             )
         self._mounts.append((host_path.resolve(), guest_path))
+
+    def _auto_mount(self, command: list, cwd: Path | None):
+        """Auto-register mounts for host paths not covered by existing mounts.
+
+        Collects absolute host paths from command args and cwd, finds their
+        common ancestor, and registers it as a mount. Restarts the container
+        if it's already running.
+        """
+        host_dirs = []
+        if cwd:
+            host_dirs.append(Path(cwd).resolve())
+        for arg in command[1:]:
+            p = Path(arg)
+            if p.is_absolute() and not str(arg).startswith("/opt"):
+                # Use parent dir — the arg may be a file or non-existent target
+                host_dirs.append(p.resolve().parent)
+
+        # Filter to paths not already covered by a mount
+        uncovered = [p for p in host_dirs if not self._is_mounted(p)]
+        if not uncovered:
+            return
+
+        # Find common parent of all uncovered paths
+        common = uncovered[0]
+        for p in uncovered[1:]:
+            while not p.is_relative_to(common):
+                common = common.parent
+
+        mount_index = len(self._mounts)
+        guest_path = f"/work{mount_index}" if mount_index > 0 else "/work"
+
+        if self._container_id:
+            logging.debug(f"New mount needed for {common} — restarting container")
+            self._stop_container()
+
+        self._mounts.append((common, guest_path))
+        logging.debug(f"Auto-mounted {common} → {guest_path}")
+
+    def _is_mounted(self, path: Path) -> bool:
+        """Check if a host path is covered by an existing mount."""
+        resolved = path.resolve()
+        return any(resolved.is_relative_to(host_root) for host_root, _ in self._mounts)
+
+    @contextmanager
+    def container(self, *mounts: Path):
+        """Context manager that runs a Docker container for the block's duration.
+
+        Args:
+            *mounts: Host directories to bind-mount. Pre-registering a parent
+                directory (e.g. the workdir) avoids container restarts when
+                iterating over subdirectories.
+        """
+        for m in mounts:
+            self.add_mount(m)
+        if self.mode == FOAMRuntime.Mode.DOCKER:
+            self._ensure_container()
+        try:
+            yield self
+        finally:
+            self._stop_container()
 
     def cleanup(self):
         """Stop the persistent Docker container."""
@@ -217,6 +288,7 @@ class FOAMRuntime:
     def _docker_exec(
         self, command: list, cwd: Path | None
     ) -> subprocess.CompletedProcess:
+        self._auto_mount(command, cwd)
         self._ensure_container()
         translated_cmd, translated_cwd = self._translate_command(command, cwd)
 
@@ -226,8 +298,12 @@ class FOAMRuntime:
             shell_cmd = f"cd {shlex.quote(translated_cwd)} && {shell_cmd}"
 
         docker_cmd = [
-            "docker", "exec", self._container_id,
-            "bash", "-c", shell_cmd,
+            "docker",
+            "exec",
+            self._container_id,
+            "bash",
+            "-c",
+            shell_cmd,
         ]
 
         logging.debug(f"Docker exec: {shell_cmd}")
@@ -243,8 +319,9 @@ class FOAMRuntime:
         Only valid in Docker mode. Native mode should read FOAM_TUTORIALS
         from the environment directly (handled by FOAM.tutorials()).
         """
-        assert self.mode != FOAMRuntime.Mode.NATIVE, \
+        assert self.mode != FOAMRuntime.Mode.NATIVE, (
             "_foam_tutorials_path() should not be called in native mode"
+        )
 
         if self._cached_foam_tutorials:
             return self._cached_foam_tutorials
@@ -252,10 +329,16 @@ class FOAMRuntime:
         self._ensure_container()
         result = subprocess.run(
             [
-                "docker", "exec", self._container_id,
-                "bash", "-c", "echo $FOAM_TUTORIALS",
+                "docker",
+                "exec",
+                self._container_id,
+                "bash",
+                "-c",
+                "echo $FOAM_TUTORIALS",
             ],
-            stdout=PIPE, stderr=PIPE, text=True,
+            stdout=PIPE,
+            stderr=PIPE,
+            text=True,
         )
         if result.returncode != 0:
             raise RuntimeError(
@@ -278,13 +361,13 @@ class FOAMRuntime:
         self._ensure_container()
         result = subprocess.run(
             ["docker", "cp", f"{self._container_id}:{remote_path}", str(local_path)],
-            stdout=PIPE, stderr=PIPE, text=True,
+            stdout=PIPE,
+            stderr=PIPE,
+            text=True,
         )
 
         if result.returncode != 0:
-            raise RuntimeError(
-                f"Failed to transfer {remote_path}: {result.stderr}"
-            )
+            raise RuntimeError(f"Failed to transfer {remote_path}: {result.stderr}")
 
     # ------------------------------------------------------------------
     # Path translation
@@ -321,7 +404,6 @@ class FOAMRuntime:
 
         translated_cwd = self._translate_path(cwd) if cwd else None
         return translated_cmd, translated_cwd
-
 
 
 _runtime: FOAMRuntime | None = None

--- a/flowboost/openfoam/runtime.py
+++ b/flowboost/openfoam/runtime.py
@@ -1,0 +1,342 @@
+import atexit
+import logging
+import os
+import shlex
+import shutil
+import subprocess
+from enum import Enum
+from pathlib import Path
+from subprocess import PIPE
+
+DOCKER_IMAGE = "flowboost/openfoam:13"
+DOCKERFILE_DIR = Path(__file__).resolve().parent / "docker"
+
+
+class FoamRuntime:
+    """Decides how to execute OpenFOAM CLI commands: natively or via Docker.
+
+    In Docker mode, a single persistent container is started on first use
+    and reused for all subsequent commands via ``docker exec``. The container
+    is removed on ``cleanup()``.
+    """
+
+    class Mode(Enum):
+        NATIVE = "native"
+        DOCKER = "docker"
+
+    FOAM_COMMANDS = {
+        "foamDictionary",
+        "foamCloneCase",
+        "foamCleanCase",
+        "foamGet",
+        "listTimes",
+    }
+
+    def __init__(self):
+        self._docker_image = os.environ.get("FLOWBOOST_FOAM_IMAGE", DOCKER_IMAGE)
+        self._cached_foam_tutorials: str | None = None
+        self._mounts: list[tuple[Path, str]] = []
+        self._container_id: str | None = None
+        self.mode = self._detect_mode()
+
+    def _detect_mode(self) -> "FoamRuntime.Mode":
+        forced = os.environ.get("FLOWBOOST_FOAM_MODE", "auto")
+
+        if forced == "native":
+            return FoamRuntime.Mode.NATIVE
+        if forced == "docker":
+            if not self._docker_available():
+                raise RuntimeError(
+                    "FLOWBOOST_FOAM_MODE=docker but Docker is not available"
+                )
+            return FoamRuntime.Mode.DOCKER
+
+        # Auto-detect: native → docker → error
+        if os.environ.get("FOAM_INST_DIR"):
+            return FoamRuntime.Mode.NATIVE
+
+        if self._docker_available():
+            return FoamRuntime.Mode.DOCKER
+
+        raise RuntimeError(
+            "OpenFOAM not available: no native install (FOAM_INST_DIR unset) "
+            "and Docker is not available"
+        )
+
+    # ------------------------------------------------------------------
+    # Availability checks
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _docker_available() -> bool:
+        try:
+            result = subprocess.run(
+                ["docker", "info"], stdout=PIPE, stderr=PIPE, timeout=5,
+            )
+            return result.returncode == 0
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            return False
+
+    def _docker_image_available(self) -> bool:
+        """Check if the configured Docker image exists locally."""
+        try:
+            result = subprocess.run(
+                ["docker", "image", "inspect", self._docker_image],
+                stdout=PIPE, stderr=PIPE, timeout=5,
+            )
+            return result.returncode == 0
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            return False
+
+    def _ensure_docker_image(self):
+        """Build the Docker image from the bundled Dockerfile if it doesn't exist."""
+        if self._docker_image_available():
+            return
+
+        if not DOCKERFILE_DIR.is_dir():
+            raise RuntimeError(
+                f"Docker image '{self._docker_image}' not found and "
+                f"Dockerfile directory not found at {DOCKERFILE_DIR}"
+            )
+
+        logging.info(
+            f"Building Docker image '{self._docker_image}' — this is a "
+            f"one-time operation..."
+        )
+        result = subprocess.run(
+            ["docker", "build", "-t", self._docker_image, str(DOCKERFILE_DIR)],
+            stderr=PIPE, text=True,
+            timeout=600,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"Failed to build Docker image: {result.stderr}"
+            )
+        logging.info(f"Docker image '{self._docker_image}' built successfully")
+
+    def is_available(self) -> bool:
+        """Check if this runtime can actually execute FOAM commands."""
+        if self.mode == FoamRuntime.Mode.NATIVE:
+            return True
+        if self.mode == FoamRuntime.Mode.DOCKER:
+            # Available if image exists or can be built
+            return self._docker_image_available() or DOCKERFILE_DIR.is_dir()
+        return False
+
+    # ------------------------------------------------------------------
+    # Container lifecycle
+    # ------------------------------------------------------------------
+
+    def _ensure_container(self):
+        """Start the persistent container if not already running."""
+        if self._container_id:
+            return
+
+        self._ensure_docker_image()
+
+        create_cmd = ["docker", "create", "--rm", "-i"]
+        for host_root, container_root in self._mounts:
+            create_cmd.extend(["-v", f"{host_root}:{container_root}"])
+        create_cmd.extend([self._docker_image, "sleep", "infinity"])
+
+        result = subprocess.run(create_cmd, stdout=PIPE, stderr=PIPE, text=True)
+        if result.returncode != 0:
+            raise RuntimeError(f"Failed to create container: {result.stderr}")
+
+        self._container_id = result.stdout.strip()
+
+        result = subprocess.run(
+            ["docker", "start", self._container_id],
+            stdout=PIPE, stderr=PIPE, text=True,
+        )
+        if result.returncode != 0:
+            self._container_id = None
+            raise RuntimeError(f"Failed to start container: {result.stderr}")
+
+        logging.debug(f"Started persistent container {self._container_id[:12]}")
+        atexit.register(self._stop_container)
+
+    def _stop_container(self):
+        """Stop and remove the persistent container."""
+        if not self._container_id:
+            return
+
+        cid = self._container_id
+        self._container_id = None
+
+        try:
+            subprocess.run(
+                ["docker", "stop", "-t", "5", cid],
+                stdout=PIPE, stderr=PIPE, timeout=15,
+            )
+        except subprocess.TimeoutExpired:
+            # Force-kill if graceful stop hangs
+            subprocess.run(
+                ["docker", "kill", cid],
+                stdout=PIPE, stderr=PIPE, timeout=10,
+            )
+
+        logging.debug(f"Stopped container {cid[:12]}")
+
+    # ------------------------------------------------------------------
+    # Mount management
+    # ------------------------------------------------------------------
+
+    def add_mount(self, host_path: Path, guest_path: str = "/work"):
+        """Register a host directory to mount into the container.
+
+        Must be called before the first FOAM command — mounts are set at
+        container creation time.
+        """
+        if self._container_id:
+            raise RuntimeError(
+                "Cannot add mounts after the container has started. "
+                "Call add_mount() before running any FOAM commands."
+            )
+        self._mounts.append((host_path.resolve(), guest_path))
+
+    def cleanup(self):
+        """Stop the persistent Docker container."""
+        self._stop_container()
+
+    # ------------------------------------------------------------------
+    # Command execution
+    # ------------------------------------------------------------------
+
+    def run(
+        self, command: list, cwd: Path | None = None
+    ) -> subprocess.CompletedProcess:
+        """Execute a command, routing FOAM commands through Docker if needed."""
+        cmd_name = Path(command[0]).name if command else ""
+
+        if self.mode == FoamRuntime.Mode.NATIVE or cmd_name not in self.FOAM_COMMANDS:
+            return subprocess.run(command, stdout=PIPE, stderr=PIPE, cwd=cwd, text=True)
+
+        return self._docker_exec(command, cwd)
+
+    def _docker_exec(
+        self, command: list, cwd: Path | None
+    ) -> subprocess.CompletedProcess:
+        self._ensure_container()
+        translated_cmd, translated_cwd = self._translate_command(command, cwd)
+
+        # Build shell command with proper quoting
+        shell_cmd = " ".join(shlex.quote(str(c)) for c in translated_cmd)
+        if translated_cwd:
+            shell_cmd = f"cd {shlex.quote(translated_cwd)} && {shell_cmd}"
+
+        docker_cmd = [
+            "docker", "exec", self._container_id,
+            "bash", "-c", shell_cmd,
+        ]
+
+        logging.debug(f"Docker exec: {shell_cmd}")
+        return subprocess.run(docker_cmd, stdout=PIPE, stderr=PIPE, text=True)
+
+    # ------------------------------------------------------------------
+    # OpenFOAM environment queries
+    # ------------------------------------------------------------------
+
+    def foam_tutorials_path(self) -> str:
+        """Query the container for $FOAM_TUTORIALS. Returns a container-internal path.
+
+        Only valid in Docker mode. Native mode should read FOAM_TUTORIALS
+        from the environment directly (handled by FOAM.tutorials()).
+        """
+        assert self.mode != FoamRuntime.Mode.NATIVE, \
+            "foam_tutorials_path() should not be called in native mode"
+
+        if self._cached_foam_tutorials:
+            return self._cached_foam_tutorials
+
+        self._ensure_container()
+        result = subprocess.run(
+            [
+                "docker", "exec", self._container_id,
+                "bash", "-c", "echo $FOAM_TUTORIALS",
+            ],
+            stdout=PIPE, stderr=PIPE, text=True,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"Failed to query FOAM_TUTORIALS from container: {result.stderr}"
+            )
+
+        path = result.stdout.strip()
+        if not path:
+            raise RuntimeError("FOAM_TUTORIALS is empty inside the container")
+
+        self._cached_foam_tutorials = path
+        return path
+
+    def transfer_file(self, remote_path: str, local_path: Path):
+        """Copy a file from the container to the host."""
+        if self.mode == FoamRuntime.Mode.NATIVE:
+            shutil.copy2(remote_path, local_path)
+            return
+
+        self._ensure_container()
+        result = subprocess.run(
+            ["docker", "cp", f"{self._container_id}:{remote_path}", str(local_path)],
+            stdout=PIPE, stderr=PIPE, text=True,
+        )
+
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"Failed to transfer {remote_path}: {result.stderr}"
+            )
+
+    # ------------------------------------------------------------------
+    # Path translation
+    # ------------------------------------------------------------------
+
+    def _translate_path(self, host_path: str | Path) -> str:
+        """Convert host absolute path to container path using registered mounts.
+
+        If the path is absolute but not under any mount, assume it's already
+        a container-internal path (e.g. tutorial paths) and pass through unchanged.
+        """
+        p = Path(host_path)
+        if not p.is_absolute():
+            return str(host_path)
+
+        resolved = p.resolve()
+        for host_root, guest_root in self._mounts:
+            try:
+                relative = resolved.relative_to(host_root)
+                return str(Path(guest_root) / relative)
+            except ValueError:
+                continue
+
+        # Not under any mount — assume container-internal path
+        return str(host_path)
+
+    def _translate_command(
+        self, command: list, cwd: Path | None
+    ) -> tuple[list[str], str | None]:
+        """Translate command args and cwd for container execution."""
+        translated_cmd = [str(command[0])]  # command name stays as-is
+        for arg in command[1:]:
+            translated_cmd.append(self._translate_path(arg))
+
+        translated_cwd = self._translate_path(cwd) if cwd else None
+        return translated_cmd, translated_cwd
+
+
+
+_runtime: FoamRuntime | None = None
+
+
+def get_runtime() -> FoamRuntime:
+    global _runtime
+    if _runtime is None:
+        _runtime = FoamRuntime()
+    return _runtime
+
+
+def reset_runtime():
+    """For testing — clear cached singleton."""
+    global _runtime
+    if _runtime is not None:
+        _runtime.cleanup()
+    _runtime = None

--- a/flowboost/openfoam/runtime.py
+++ b/flowboost/openfoam/runtime.py
@@ -30,6 +30,7 @@ class FOAMRuntime:
         "foamCloneCase",
         "foamCleanCase",
         "foamGet",
+        "foamToVTK",
         "listTimes",
     }
 
@@ -257,6 +258,7 @@ class FOAMRuntime:
                 directory (e.g. the workdir) avoids container restarts when
                 iterating over subdirectories.
         """
+        prev_mounts = self._mounts.copy()
         for m in mounts:
             self.add_mount(m)
         if self.mode == FOAMRuntime.Mode.DOCKER:
@@ -265,6 +267,7 @@ class FOAMRuntime:
             yield self
         finally:
             self._stop_container()
+            self._mounts = prev_mounts
 
     def cleanup(self):
         """Stop the persistent Docker container."""

--- a/flowboost/session/session.py
+++ b/flowboost/session/session.py
@@ -193,7 +193,7 @@ class Session:
             new_cases = self.loop_optimizer_once(num_new_cases=int(limit))
             logging.info(f"{len(new_cases)} new case(s) prepared")
             self._pretty_print_cases(new_cases)
-            return
+            return new_cases
 
         logging.info("Entering persistent optimization")
         self.persistent_optimization()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flowboost"
-version = "0.2.2"
+version = "0.2.3"
 description = "Multi-objective Bayesian optimization library for OpenFOAM"
 license = "Apache-2.0"
 authors = [
@@ -42,12 +42,22 @@ dependencies = [
 
 [project.optional-dependencies]
 lts-cpu = ["polars-lts-cpu>=0.20"]
+viz = [
+    "pyvista>=0.47.1",
+]
 
 [project.urls]
 Repository = "https://github.com/499602D2/flowboost"
 
 [dependency-groups]
-dev = ["pytest>=8", "pytest-cov>=5", "pytest-xdist>=3.8"]
+dev = [
+    "pre-commit>=4.5.1",
+    "pytest>=8",
+    "pytest-cov>=5",
+    "pytest-xdist>=3.8",
+    "ruff>=0.15.5",
+    "ty>=0.0.21",
+]
 
 [build-system]
 requires = ["uv_build>=0.10.4,<0.11.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,10 @@ module-root = ""
 minversion = "8.0"
 addopts = "-ra -v -n 4"
 testpaths = ["tests"]
-markers = ["slow: marks tests as slow (deselect with '-m \"not slow\"')"]
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "native_foam_only: requires native OpenFOAM (not Docker)",
+]
 log_cli = true
 log_cli_level = "INFO"
 log_cli_format = "%(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import pytest
 
 from flowboost.openfoam.case import Case
 from flowboost.openfoam.interface import FOAM
-from flowboost.openfoam.runtime import FoamRuntime, get_runtime
+from flowboost.openfoam.runtime import FOAMRuntime, get_runtime
 
 
 @pytest.fixture(scope="session")
@@ -15,7 +15,7 @@ def data_dir():
 
 @pytest.fixture(scope="session")
 def foam_runtime(tmp_path_factory):
-    """Session-scoped fixture that provides a configured FoamRuntime."""
+    """Session-scoped fixture that provides a configured FOAMRuntime."""
     try:
         runtime = get_runtime()
     except RuntimeError:
@@ -26,7 +26,7 @@ def foam_runtime(tmp_path_factory):
         pytest.skip("OpenFOAM runtime not usable (Docker image missing or cannot be built)")
         return
 
-    if runtime.mode != FoamRuntime.Mode.NATIVE:
+    if runtime.mode != FOAMRuntime.Mode.NATIVE:
         # Mount tmp dir for test output
         mount_root = tmp_path_factory.getbasetemp()
         runtime.add_mount(mount_root, "/work")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import pytest
 
 from flowboost.openfoam.case import Case
 from flowboost.openfoam.interface import FOAM
+from flowboost.openfoam.runtime import FoamRuntime, get_runtime
 
 
 @pytest.fixture(scope="session")
@@ -13,15 +14,33 @@ def data_dir():
 
 
 @pytest.fixture(scope="session")
-def foam_in_env():
-    """
-    Ensures OpenFOAM is sourced. If not, the test is skipped.
+def foam_runtime(tmp_path_factory):
+    """Session-scoped fixture that provides a configured FoamRuntime."""
+    try:
+        runtime = get_runtime()
+    except RuntimeError:
+        pytest.skip("OpenFOAM not available (no native install, no Docker)")
+        return
 
-    Returns:
-        bool: FOAM sourced?
-    """
-    if not FOAM.in_env():
-        pytest.skip("OpenFOAM not sourced")
+    if not runtime.is_available():
+        pytest.skip("OpenFOAM runtime not usable (Docker image missing or cannot be built)")
+        return
+
+    if runtime.mode != FoamRuntime.Mode.NATIVE:
+        # Mount tmp dir for test output
+        mount_root = tmp_path_factory.getbasetemp()
+        runtime.add_mount(mount_root, "/work")
+        # Mount test data dir so foamDictionary can access test case files
+        tests_dir = Path(__file__).parent
+        runtime.add_mount(tests_dir, "/testdata")
+
+    yield runtime
+    runtime.cleanup()
+
+
+@pytest.fixture(scope="session")
+def foam_in_env(foam_runtime):
+    """Ensures OpenFOAM is available (native or Docker). Skips if not."""
     return True
 
 

--- a/tests/flowboost/manager/test_docker_local.py
+++ b/tests/flowboost/manager/test_docker_local.py
@@ -1,0 +1,131 @@
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from flowboost.manager.interfaces.docker_local import DockerLocal
+from flowboost.openfoam.runtime import FOAMRuntime
+
+
+@pytest.fixture
+def manager(tmp_path):
+    with patch.object(FOAMRuntime, "_docker_available", return_value=True):
+        return DockerLocal(wdir=tmp_path, job_limit=2)
+
+
+class TestIsAvailable:
+    def test_available_when_docker_present(self):
+        with patch.object(FOAMRuntime, "_docker_available", return_value=True):
+            assert DockerLocal._is_available()
+
+    def test_unavailable_when_no_docker(self):
+        with patch.object(FOAMRuntime, "_docker_available", return_value=False):
+            assert not DockerLocal._is_available()
+
+
+class TestSubmitJob:
+    def test_submit_builds_correct_command(self, manager):
+        mock_result = MagicMock(returncode=0, stdout="abc123containerid\n")
+        script = Path("/tmp/cases/mycase/Allrun")
+        cwd = Path("/tmp/cases/mycase")
+
+        with (
+            patch("subprocess.run", return_value=mock_result) as mock_run,
+            patch("flowboost.manager.interfaces.docker_local.get_runtime") as mock_rt,
+        ):
+            job_id = manager._submit_job("flwbst_job01", cwd, script)
+
+        assert job_id == "abc123containerid"
+        mock_rt()._ensure_docker_image.assert_called_once()
+
+        call_args = mock_run.call_args[0][0]
+        assert call_args[:3] == ["docker", "run", "-d"]
+        assert "--name" in call_args
+        assert call_args[call_args.index("--name") + 1] == "flwbst_job01"
+        assert f"{cwd}:/work" in call_args
+        assert "Allrun" == call_args[-1]
+
+    def test_submit_passes_script_args_as_env(self, manager):
+        mock_result = MagicMock(returncode=0, stdout="containerid\n")
+
+        with (
+            patch("subprocess.run", return_value=mock_result) as mock_run,
+            patch("flowboost.manager.interfaces.docker_local.get_runtime"),
+        ):
+            manager._submit_job(
+                "job", Path("/work"), Path("/work/Allrun"),
+                script_args={"NPROCS": "4", "SOLVER": "simpleFoam"},
+            )
+
+        call_args = mock_run.call_args[0][0]
+        env_pairs = []
+        for i, arg in enumerate(call_args):
+            if arg == "-e":
+                env_pairs.append(call_args[i + 1])
+        assert "NPROCS=4" in env_pairs
+        assert "SOLVER=simpleFoam" in env_pairs
+
+    def test_submit_returns_none_on_failure(self, manager):
+        mock_result = MagicMock(returncode=1, stderr="error")
+
+        with (
+            patch("subprocess.run", return_value=mock_result),
+            patch("flowboost.manager.interfaces.docker_local.get_runtime"),
+        ):
+            result = manager._submit_job("job", Path("/work"), Path("/work/Allrun"))
+
+        assert result is None
+
+
+class TestJobHasFinished:
+    def test_running_container(self, manager):
+        mock_result = MagicMock(returncode=0, stdout="true\n")
+
+        with patch("subprocess.run", return_value=mock_result):
+            assert not manager._job_has_finished("abc123")
+
+    def test_stopped_container_is_cleaned_up(self, manager):
+        mock_result = MagicMock(returncode=0, stdout="false\n")
+
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            assert manager._job_has_finished("abc123")
+
+        # Should have called docker rm
+        rm_call = mock_run.call_args_list[-1]
+        assert rm_call[0][0][:2] == ["docker", "rm"]
+
+    def test_missing_container_is_finished(self, manager):
+        mock_result = MagicMock(returncode=1)
+
+        with patch("subprocess.run", return_value=mock_result):
+            assert manager._job_has_finished("gone123")
+
+    def test_timeout_returns_not_finished(self, manager):
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="", timeout=10)):
+            assert not manager._job_has_finished("slow123")
+
+
+class TestCancelJob:
+    def test_cancel_stops_and_removes(self, manager):
+        mock_result = MagicMock(returncode=0)
+
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            assert manager._cancel_job("abc123")
+
+        cmds = [call[0][0][:2] for call in mock_run.call_args_list]
+        assert ["docker", "stop"] in cmds
+        assert ["docker", "rm"] in cmds
+
+    def test_cancel_force_kills_on_timeout(self, manager):
+        def side_effect(cmd, **kwargs):
+            if cmd[1] == "stop":
+                raise subprocess.TimeoutExpired(cmd="", timeout=20)
+            return MagicMock(returncode=0)
+
+        with patch("subprocess.run", side_effect=side_effect) as mock_run:
+            result = manager._cancel_job("stuck123")
+
+        assert not result
+        cmds = [call[0][0][:2] for call in mock_run.call_args_list]
+        assert ["docker", "kill"] in cmds

--- a/tests/flowboost/manager/test_docker_local.py
+++ b/tests/flowboost/manager/test_docker_local.py
@@ -44,7 +44,7 @@ class TestSubmitJob:
         assert "--name" in call_args
         assert call_args[call_args.index("--name") + 1] == "flwbst_job01"
         assert f"{cwd}:/work" in call_args
-        assert "Allrun" == call_args[-1]
+        assert "./Allrun" == call_args[-1]
 
     def test_submit_passes_script_args_as_env(self, manager):
         mock_result = MagicMock(returncode=0, stdout="containerid\n")
@@ -54,7 +54,9 @@ class TestSubmitJob:
             patch("flowboost.manager.interfaces.docker_local.get_runtime"),
         ):
             manager._submit_job(
-                "job", Path("/work"), Path("/work/Allrun"),
+                "job",
+                Path("/work"),
+                Path("/work/Allrun"),
                 script_args={"NPROCS": "4", "SOLVER": "simpleFoam"},
             )
 
@@ -102,7 +104,9 @@ class TestJobHasFinished:
             assert manager._job_has_finished("gone123")
 
     def test_timeout_returns_not_finished(self, manager):
-        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="", timeout=10)):
+        with patch(
+            "subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="", timeout=10)
+        ):
             assert not manager._job_has_finished("slow123")
 
 

--- a/tests/flowboost/manager/test_manager_prod.py
+++ b/tests/flowboost/manager/test_manager_prod.py
@@ -40,11 +40,13 @@ def test_abstract_methods(foam_in_env, manager: Manager):
     # Check the job pool
     logging.debug(f"Manager job pool status:\n{manager._status_print()}")
 
-    # Try free slots (also runs _has_finished)
+    # Try free slots (also runs _has_finished).
+    # The job may have already finished (e.g. script fails immediately when
+    # OpenFOAM isn't on PATH), so accept either "running" or "done" counts.
     slots = manager.free_slots()
-    assert (
-        slots == manager.job_limit - 1
-    ), f"Free slots incorrect: {slots} != {manager.job_limit-1}"
+    assert slots >= manager.job_limit - 1, (
+        f"Free slots incorrect: {slots} < {manager.job_limit - 1}"
+    )
 
     # Cancel
     for job in manager.job_pool:

--- a/tests/flowboost/openfoam/test_case.py
+++ b/tests/flowboost/openfoam/test_case.py
@@ -46,9 +46,10 @@ def test_dictionary_link(foam_in_env, tutorial_case):
     assert reader.entry("type") == "sprayCloud"
 
 
-def test_case_clone_and_removal(foam_in_env, tutorial_case, new_case_dir):
+def test_case_clone_and_removal(foam_in_env, tutorial_case, tmp_path):
     # Copy tutorial case to a new folder and test removal
-    new_case = tutorial_case.clone(clone_to=new_case_dir)
+    clone_dest = tmp_path / "clonedCase"
+    new_case = tutorial_case.clone(clone_to=clone_dest)
     assert new_case.path.exists()
 
     # Test safe deletion

--- a/tests/flowboost/openfoam/test_dictionary.py
+++ b/tests/flowboost/openfoam/test_dictionary.py
@@ -6,13 +6,29 @@ import pytest
 
 from flowboost.openfoam.dictionary import Dictionary, DictionaryReader
 from flowboost.openfoam.interface import FOAM
+from flowboost.openfoam.runtime import FoamRuntime, get_runtime
 
 
 @pytest.fixture
 def tutorial_dictionary_reader(foam_in_env, tmp_path) -> Callable[[str], DictionaryReader]:
-    """Fixture to create a Dictionary reader for testing."""
+    """Fixture to create a Dictionary reader for testing.
+
+    In non-native mode, copies the tutorial file to tmp_path so it lives on
+    the host filesystem and survives across remote command invocations.
+    """
     def _reader(path: str) -> DictionaryReader:
-        return DictionaryReader(FOAM.tutorials() / path)
+        runtime = get_runtime()
+
+        if runtime.mode == FoamRuntime.Mode.NATIVE:
+            return DictionaryReader(FOAM.tutorials() / path)
+
+        # Non-native: copy the tutorial file from the VM/container to tmp_path
+        tutorials = FOAM.tutorials()  # remote-internal path string
+        remote_path = f"{tutorials}/{path}"
+        local_dest = tmp_path / Path(path).name
+
+        runtime.transfer_file(remote_path, local_dest)
+        return DictionaryReader(local_dest)
 
     return _reader
 
@@ -20,11 +36,15 @@ def tutorial_dictionary_reader(foam_in_env, tmp_path) -> Callable[[str], Diction
 @pytest.fixture
 def foam_tutorial_dict_paths(foam_in_env) -> Generator[Path, None, None]:
     """Generates FOAM dictionary paths from tutorials folder."""
+    runtime = get_runtime()
+    if runtime.mode != FoamRuntime.Mode.NATIVE:
+        pytest.skip("Requires native OpenFOAM (host-side directory traversal)")
+
     tutorials_path = FOAM.tutorials()
-    assert tutorials_path.exists(
+    assert Path(tutorials_path).exists(
     ), f"Tutorials folder does not exist: {tutorials_path}"
 
-    for constant_system_folder in tutorials_path.rglob('*'):
+    for constant_system_folder in Path(tutorials_path).rglob('*'):
         if constant_system_folder.name in ('constant', 'system'):
             for foam_file in constant_system_folder.iterdir():
                 if foam_file.is_file() and foam_file.suffix != '.dat':
@@ -60,9 +80,9 @@ def test_entry_read_and_write(tutorial_dictionary_reader):
     assert updated_mol_weight == new_mol_weight, "Write operation failed"
 
     # Reset the value back to original
-    reader.write("reactants/specie/molWeight", mol_weight)
+    reader.write("reactants/specie/molWeight", 16.0243)
     reset_mol_weight = reader.entry("reactants/specie/molWeight")
-    assert reset_mol_weight == mol_weight, "Reset operation failed"
+    assert reset_mol_weight == 16.0243, "Reset operation failed"
 
 
 def test_add_and_delete_entry(tutorial_dictionary_reader):
@@ -113,8 +133,8 @@ def test_entry_indexing(tutorial_dictionary_reader):
         test_array_key) is None, "Failed to delete the test array entry"
 
 
-def test_linking(tutorial_dictionary_reader):
-    """Test linking between dictionary entries."""
+def test_linking():
+    """Test linking between dictionary entries. No FOAM CLI needed."""
     header_link = Dictionary.link(
         "constant/physicalProperties").entry("FoamFile/format")
 

--- a/tests/flowboost/openfoam/test_dictionary.py
+++ b/tests/flowboost/openfoam/test_dictionary.py
@@ -6,7 +6,7 @@ import pytest
 
 from flowboost.openfoam.dictionary import Dictionary, DictionaryReader
 from flowboost.openfoam.interface import FOAM
-from flowboost.openfoam.runtime import FoamRuntime, get_runtime
+from flowboost.openfoam.runtime import FOAMRuntime, get_runtime
 
 
 @pytest.fixture
@@ -19,7 +19,7 @@ def tutorial_dictionary_reader(foam_in_env, tmp_path) -> Callable[[str], Diction
     def _reader(path: str) -> DictionaryReader:
         runtime = get_runtime()
 
-        if runtime.mode == FoamRuntime.Mode.NATIVE:
+        if runtime.mode == FOAMRuntime.Mode.NATIVE:
             return DictionaryReader(FOAM.tutorials() / path)
 
         # Non-native: copy the tutorial file from the VM/container to tmp_path
@@ -37,7 +37,7 @@ def tutorial_dictionary_reader(foam_in_env, tmp_path) -> Callable[[str], Diction
 def foam_tutorial_dict_paths(foam_in_env) -> Generator[Path, None, None]:
     """Generates FOAM dictionary paths from tutorials folder."""
     runtime = get_runtime()
-    if runtime.mode != FoamRuntime.Mode.NATIVE:
+    if runtime.mode != FOAMRuntime.Mode.NATIVE:
         pytest.skip("Requires native OpenFOAM (host-side directory traversal)")
 
     tutorials_path = FOAM.tutorials()

--- a/tests/flowboost/openfoam/test_runtime.py
+++ b/tests/flowboost/openfoam/test_runtime.py
@@ -1,0 +1,148 @@
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from flowboost.openfoam.runtime import FoamRuntime, get_runtime, reset_runtime
+
+
+class TestDetectMode:
+    def test_native_when_foam_inst_dir_set(self):
+        with patch.dict(os.environ, {"FOAM_INST_DIR": "/opt/openfoam", "FLOWBOOST_FOAM_MODE": "auto"}):
+            runtime = FoamRuntime()
+            assert runtime.mode == FoamRuntime.Mode.NATIVE
+
+    def test_forced_native(self):
+        with patch.dict(os.environ, {"FLOWBOOST_FOAM_MODE": "native"}, clear=False):
+            runtime = FoamRuntime()
+            assert runtime.mode == FoamRuntime.Mode.NATIVE
+
+    def test_forced_docker_without_docker_raises(self):
+        with (
+            patch.dict(os.environ, {"FLOWBOOST_FOAM_MODE": "docker"}, clear=False),
+            patch.object(FoamRuntime, "_docker_available", return_value=False),
+        ):
+            with pytest.raises(RuntimeError, match="Docker is not available"):
+                FoamRuntime()
+
+    def test_forced_docker_with_docker(self):
+        with (
+            patch.dict(os.environ, {"FLOWBOOST_FOAM_MODE": "docker"}, clear=False),
+            patch.object(FoamRuntime, "_docker_available", return_value=True),
+        ):
+            runtime = FoamRuntime()
+            assert runtime.mode == FoamRuntime.Mode.DOCKER
+
+    def test_auto_falls_to_docker_when_no_foam(self):
+        with (
+            patch.dict(os.environ, {"FLOWBOOST_FOAM_MODE": "auto"}, clear=False),
+            patch.object(FoamRuntime, "_docker_available", return_value=True),
+        ):
+            os.environ.pop("FOAM_INST_DIR", None)
+            runtime = FoamRuntime()
+            assert runtime.mode == FoamRuntime.Mode.DOCKER
+
+    def test_auto_raises_when_nothing_available(self):
+        with (
+            patch.dict(os.environ, {"FLOWBOOST_FOAM_MODE": "auto"}, clear=False),
+            patch.object(FoamRuntime, "_docker_available", return_value=False),
+        ):
+            os.environ.pop("FOAM_INST_DIR", None)
+            with pytest.raises(RuntimeError, match="OpenFOAM not available"):
+                FoamRuntime()
+
+
+class TestTranslatePath:
+    def test_relative_path_unchanged(self):
+        with patch.dict(os.environ, {"FOAM_INST_DIR": "/opt/openfoam"}):
+            runtime = FoamRuntime()
+        assert runtime._translate_path("constant/U") == "constant/U"
+
+    def test_absolute_under_mount(self):
+        with patch.dict(os.environ, {"FOAM_INST_DIR": "/opt/openfoam"}):
+            runtime = FoamRuntime()
+        runtime.add_mount(Path("/tmp/cases"), "/work")
+        result = runtime._translate_path("/tmp/cases/mycase/0/U")
+        assert result == "/work/mycase/0/U"
+
+    def test_absolute_not_under_mount_passes_through(self):
+        with patch.dict(os.environ, {"FOAM_INST_DIR": "/opt/openfoam"}):
+            runtime = FoamRuntime()
+        runtime.add_mount(Path("/tmp/cases"), "/work")
+        result = runtime._translate_path("/opt/openfoam/tutorials/X/Y")
+        assert result == "/opt/openfoam/tutorials/X/Y"
+
+
+class TestTranslateCommand:
+    def test_foam_command_args_translated(self):
+        with patch.dict(os.environ, {"FOAM_INST_DIR": "/opt/openfoam"}):
+            runtime = FoamRuntime()
+        runtime.add_mount(Path("/tmp/cases"), "/work")
+
+        cmd = ["foamDictionary", "/tmp/cases/mycase/constant/U", "-entry", "inlet"]
+        translated_cmd, translated_cwd = runtime._translate_command(cmd, None)
+
+        assert translated_cmd[0] == "foamDictionary"
+        assert translated_cmd[1] == "/work/mycase/constant/U"
+        assert translated_cmd[2] == "-entry"
+        assert translated_cmd[3] == "inlet"
+
+    def test_cwd_translated(self):
+        with patch.dict(os.environ, {"FOAM_INST_DIR": "/opt/openfoam"}):
+            runtime = FoamRuntime()
+        runtime.add_mount(Path("/tmp/cases"), "/work")
+
+        _, translated_cwd = runtime._translate_command(
+            ["listTimes"], Path("/tmp/cases/mycase")
+        )
+        assert translated_cwd == "/work/mycase"
+
+
+class TestRunRouting:
+    def test_non_foam_command_runs_natively(self):
+        """Non-FOAM commands should bypass Docker even in DOCKER mode."""
+        with (
+            patch.dict(os.environ, {"FLOWBOOST_FOAM_MODE": "docker"}, clear=False),
+            patch.object(FoamRuntime, "_docker_available", return_value=True),
+        ):
+            runtime = FoamRuntime()
+
+        result = runtime.run(["echo", "hello"])
+        assert result.returncode == 0
+        assert "hello" in result.stdout
+
+    def test_foam_command_detected(self):
+        """FOAM commands should be recognized by name."""
+        assert "foamDictionary" in FoamRuntime.FOAM_COMMANDS
+        assert "foamCloneCase" in FoamRuntime.FOAM_COMMANDS
+        assert "echo" not in FoamRuntime.FOAM_COMMANDS
+
+
+class TestSingleton:
+    def test_get_runtime_returns_same_instance(self):
+        import flowboost.openfoam.runtime as rt
+        saved = rt._runtime
+        rt._runtime = None
+        try:
+            with patch.dict(os.environ, {"FOAM_INST_DIR": "/opt/openfoam"}):
+                r1 = get_runtime()
+                r2 = get_runtime()
+                assert r1 is r2
+        finally:
+            rt._runtime = saved
+
+    def test_reset_runtime_clears(self):
+        import flowboost.openfoam.runtime as rt
+        saved = rt._runtime
+        rt._runtime = None
+        try:
+            with patch.dict(os.environ, {"FOAM_INST_DIR": "/opt/openfoam"}):
+                r1 = get_runtime()
+                # Use module-level assignment instead of reset_runtime()
+                # to avoid stopping a real container
+                rt._runtime = None
+                r2 = get_runtime()
+                assert r1 is not r2
+        finally:
+            rt._runtime = saved

--- a/tests/flowboost/openfoam/test_runtime.py
+++ b/tests/flowboost/openfoam/test_runtime.py
@@ -4,71 +4,71 @@ from unittest.mock import patch
 
 import pytest
 
-from flowboost.openfoam.runtime import FoamRuntime, get_runtime, reset_runtime
+from flowboost.openfoam.runtime import FOAMRuntime, get_runtime, reset_runtime
 
 
 class TestDetectMode:
     def test_native_when_foam_inst_dir_set(self):
         with patch.dict(os.environ, {"FOAM_INST_DIR": "/opt/openfoam", "FLOWBOOST_FOAM_MODE": "auto"}):
-            runtime = FoamRuntime()
-            assert runtime.mode == FoamRuntime.Mode.NATIVE
+            runtime = FOAMRuntime()
+            assert runtime.mode == FOAMRuntime.Mode.NATIVE
 
     def test_forced_native(self):
         with patch.dict(os.environ, {"FLOWBOOST_FOAM_MODE": "native"}, clear=False):
-            runtime = FoamRuntime()
-            assert runtime.mode == FoamRuntime.Mode.NATIVE
+            runtime = FOAMRuntime()
+            assert runtime.mode == FOAMRuntime.Mode.NATIVE
 
     def test_forced_docker_without_docker_raises(self):
         with (
             patch.dict(os.environ, {"FLOWBOOST_FOAM_MODE": "docker"}, clear=False),
-            patch.object(FoamRuntime, "_docker_available", return_value=False),
+            patch.object(FOAMRuntime, "_docker_available", return_value=False),
         ):
             with pytest.raises(RuntimeError, match="Docker is not available"):
-                FoamRuntime()
+                FOAMRuntime()
 
     def test_forced_docker_with_docker(self):
         with (
             patch.dict(os.environ, {"FLOWBOOST_FOAM_MODE": "docker"}, clear=False),
-            patch.object(FoamRuntime, "_docker_available", return_value=True),
+            patch.object(FOAMRuntime, "_docker_available", return_value=True),
         ):
-            runtime = FoamRuntime()
-            assert runtime.mode == FoamRuntime.Mode.DOCKER
+            runtime = FOAMRuntime()
+            assert runtime.mode == FOAMRuntime.Mode.DOCKER
 
     def test_auto_falls_to_docker_when_no_foam(self):
         with (
             patch.dict(os.environ, {"FLOWBOOST_FOAM_MODE": "auto"}, clear=False),
-            patch.object(FoamRuntime, "_docker_available", return_value=True),
+            patch.object(FOAMRuntime, "_docker_available", return_value=True),
         ):
             os.environ.pop("FOAM_INST_DIR", None)
-            runtime = FoamRuntime()
-            assert runtime.mode == FoamRuntime.Mode.DOCKER
+            runtime = FOAMRuntime()
+            assert runtime.mode == FOAMRuntime.Mode.DOCKER
 
     def test_auto_raises_when_nothing_available(self):
         with (
             patch.dict(os.environ, {"FLOWBOOST_FOAM_MODE": "auto"}, clear=False),
-            patch.object(FoamRuntime, "_docker_available", return_value=False),
+            patch.object(FOAMRuntime, "_docker_available", return_value=False),
         ):
             os.environ.pop("FOAM_INST_DIR", None)
             with pytest.raises(RuntimeError, match="OpenFOAM not available"):
-                FoamRuntime()
+                FOAMRuntime()
 
 
 class TestTranslatePath:
     def test_relative_path_unchanged(self):
         with patch.dict(os.environ, {"FOAM_INST_DIR": "/opt/openfoam"}):
-            runtime = FoamRuntime()
+            runtime = FOAMRuntime()
         assert runtime._translate_path("constant/U") == "constant/U"
 
     def test_absolute_under_mount(self):
         with patch.dict(os.environ, {"FOAM_INST_DIR": "/opt/openfoam"}):
-            runtime = FoamRuntime()
+            runtime = FOAMRuntime()
         runtime.add_mount(Path("/tmp/cases"), "/work")
         result = runtime._translate_path("/tmp/cases/mycase/0/U")
         assert result == "/work/mycase/0/U"
 
     def test_absolute_not_under_mount_passes_through(self):
         with patch.dict(os.environ, {"FOAM_INST_DIR": "/opt/openfoam"}):
-            runtime = FoamRuntime()
+            runtime = FOAMRuntime()
         runtime.add_mount(Path("/tmp/cases"), "/work")
         result = runtime._translate_path("/opt/openfoam/tutorials/X/Y")
         assert result == "/opt/openfoam/tutorials/X/Y"
@@ -77,7 +77,7 @@ class TestTranslatePath:
 class TestTranslateCommand:
     def test_foam_command_args_translated(self):
         with patch.dict(os.environ, {"FOAM_INST_DIR": "/opt/openfoam"}):
-            runtime = FoamRuntime()
+            runtime = FOAMRuntime()
         runtime.add_mount(Path("/tmp/cases"), "/work")
 
         cmd = ["foamDictionary", "/tmp/cases/mycase/constant/U", "-entry", "inlet"]
@@ -90,7 +90,7 @@ class TestTranslateCommand:
 
     def test_cwd_translated(self):
         with patch.dict(os.environ, {"FOAM_INST_DIR": "/opt/openfoam"}):
-            runtime = FoamRuntime()
+            runtime = FOAMRuntime()
         runtime.add_mount(Path("/tmp/cases"), "/work")
 
         _, translated_cwd = runtime._translate_command(
@@ -104,9 +104,9 @@ class TestRunRouting:
         """Non-FOAM commands should bypass Docker even in DOCKER mode."""
         with (
             patch.dict(os.environ, {"FLOWBOOST_FOAM_MODE": "docker"}, clear=False),
-            patch.object(FoamRuntime, "_docker_available", return_value=True),
+            patch.object(FOAMRuntime, "_docker_available", return_value=True),
         ):
-            runtime = FoamRuntime()
+            runtime = FOAMRuntime()
 
         result = runtime.run(["echo", "hello"])
         assert result.returncode == 0
@@ -114,9 +114,9 @@ class TestRunRouting:
 
     def test_foam_command_detected(self):
         """FOAM commands should be recognized by name."""
-        assert "foamDictionary" in FoamRuntime.FOAM_COMMANDS
-        assert "foamCloneCase" in FoamRuntime.FOAM_COMMANDS
-        assert "echo" not in FoamRuntime.FOAM_COMMANDS
+        assert "foamDictionary" in FOAMRuntime.FOAM_COMMANDS
+        assert "foamCloneCase" in FOAMRuntime.FOAM_COMMANDS
+        assert "echo" not in FOAMRuntime.FOAM_COMMANDS
 
 
 class TestSingleton:

--- a/tests/flowboost/openfoam/test_runtime.py
+++ b/tests/flowboost/openfoam/test_runtime.py
@@ -4,12 +4,15 @@ from unittest.mock import patch
 
 import pytest
 
-from flowboost.openfoam.runtime import FOAMRuntime, get_runtime, reset_runtime
+from flowboost.openfoam.runtime import FOAMRuntime, get_runtime
 
 
 class TestDetectMode:
     def test_native_when_foam_inst_dir_set(self):
-        with patch.dict(os.environ, {"FOAM_INST_DIR": "/opt/openfoam", "FLOWBOOST_FOAM_MODE": "auto"}):
+        with patch.dict(
+            os.environ,
+            {"FOAM_INST_DIR": "/opt/openfoam", "FLOWBOOST_FOAM_MODE": "auto"},
+        ):
             runtime = FOAMRuntime()
             assert runtime.mode == FOAMRuntime.Mode.NATIVE
 
@@ -119,9 +122,69 @@ class TestRunRouting:
         assert "echo" not in FOAMRuntime.FOAM_COMMANDS
 
 
+class TestContainer:
+    def _make_docker_runtime(self):
+        with (
+            patch.dict(os.environ, {"FLOWBOOST_FOAM_MODE": "docker"}, clear=False),
+            patch.object(FOAMRuntime, "_docker_available", return_value=True),
+        ):
+            return FOAMRuntime()
+
+    def test_container_starts_and_stops(self):
+        runtime = self._make_docker_runtime()
+        with (
+            patch.object(runtime, "_ensure_container") as mock_ensure,
+            patch.object(runtime, "_stop_container") as mock_stop,
+            patch.object(runtime, "_ensure_docker_image"),
+        ):
+            with runtime.container():
+                mock_ensure.assert_called_once()
+            mock_stop.assert_called_once()
+
+    def test_container_registers_mounts(self):
+        runtime = self._make_docker_runtime()
+        mount_a = Path("/tmp/work_a")
+        mount_b = Path("/tmp/work_b")
+
+        with (
+            patch.object(runtime, "_ensure_container"),
+            patch.object(runtime, "_stop_container"),
+        ):
+            with runtime.container(mount_a, mount_b):
+                assert len(runtime._mounts) == 2
+                host_roots = [m[0] for m in runtime._mounts]
+                assert mount_a.resolve() in host_roots
+                assert mount_b.resolve() in host_roots
+
+    def test_container_noop_in_native_mode(self):
+        with patch.dict(os.environ, {"FOAM_INST_DIR": "/opt/openfoam"}):
+            runtime = FOAMRuntime()
+
+        with (
+            patch.object(runtime, "_ensure_container") as mock_ensure,
+            patch.object(runtime, "_stop_container") as mock_stop,
+        ):
+            with runtime.container() as rt:
+                assert rt is runtime
+                mock_ensure.assert_not_called()
+            mock_stop.assert_called_once()
+
+    def test_container_stops_on_exception(self):
+        runtime = self._make_docker_runtime()
+        with (
+            patch.object(runtime, "_ensure_container"),
+            patch.object(runtime, "_stop_container") as mock_stop,
+        ):
+            with pytest.raises(ValueError):
+                with runtime.container():
+                    raise ValueError("boom")
+            mock_stop.assert_called_once()
+
+
 class TestSingleton:
     def test_get_runtime_returns_same_instance(self):
         import flowboost.openfoam.runtime as rt
+
         saved = rt._runtime
         rt._runtime = None
         try:
@@ -134,6 +197,7 @@ class TestSingleton:
 
     def test_reset_runtime_clears(self):
         import flowboost.openfoam.runtime as rt
+
         saved = rt._runtime
         rt._runtime = None
         try:

--- a/tests/flowboost/openfoam/test_runtime.py
+++ b/tests/flowboost/openfoam/test_runtime.py
@@ -180,6 +180,34 @@ class TestContainer:
                     raise ValueError("boom")
             mock_stop.assert_called_once()
 
+    def test_container_restores_mounts_on_exit(self):
+        runtime = self._make_docker_runtime()
+        runtime._mounts = [(Path("/existing"), "/work")]
+
+        with (
+            patch.object(runtime, "_ensure_container"),
+            patch.object(runtime, "_stop_container"),
+        ):
+            with runtime.container(Path("/tmp/new")):
+                assert len(runtime._mounts) == 2
+            assert len(runtime._mounts) == 1
+            assert runtime._mounts[0] == (Path("/existing"), "/work")
+
+    def test_container_restores_mounts_on_exception(self):
+        runtime = self._make_docker_runtime()
+        runtime._mounts = [(Path("/existing"), "/work")]
+
+        with (
+            patch.object(runtime, "_ensure_container"),
+            patch.object(runtime, "_stop_container"),
+        ):
+            with pytest.raises(ValueError):
+                with runtime.container(Path("/tmp/new")):
+                    assert len(runtime._mounts) == 2
+                    raise ValueError("boom")
+            assert len(runtime._mounts) == 1
+            assert runtime._mounts[0] == (Path("/existing"), "/work")
+
 
 class TestSingleton:
     def test_get_runtime_returns_same_instance(self):

--- a/tests/flowboost/openfoam/test_runtime.py
+++ b/tests/flowboost/openfoam/test_runtime.py
@@ -1,10 +1,53 @@
 import os
+import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
-from flowboost.openfoam.runtime import FOAMRuntime, get_runtime
+from flowboost.openfoam.runtime import FOAMRuntime, get_runtime, reset_runtime
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def native_runtime():
+    """FOAMRuntime in native mode (no Docker needed)."""
+    with patch.dict(os.environ, {"FOAM_INST_DIR": "/opt/openfoam"}):
+        yield FOAMRuntime()
+
+
+@pytest.fixture
+def docker_runtime():
+    """FOAMRuntime in docker mode (Docker availability faked)."""
+    with (
+        patch.dict(os.environ, {"FLOWBOOST_FOAM_MODE": "docker"}, clear=False),
+        patch.object(FOAMRuntime, "_docker_available", return_value=True),
+    ):
+        yield FOAMRuntime()
+
+
+@pytest.fixture
+def docker_runtime_no_lifecycle(docker_runtime):
+    """Docker runtime with container lifecycle methods mocked out.
+
+    Tests can assert on the mocks via ``runtime._ensure_container`` and
+    ``runtime._stop_container`` (they are MagicMock instances while the
+    fixture is active).
+    """
+    with (
+        patch.object(docker_runtime, "_ensure_container"),
+        patch.object(docker_runtime, "_stop_container"),
+    ):
+        yield docker_runtime
+
+
+# ---------------------------------------------------------------------------
+# Mode detection
+# ---------------------------------------------------------------------------
 
 
 class TestDetectMode:
@@ -29,13 +72,8 @@ class TestDetectMode:
             with pytest.raises(RuntimeError, match="Docker is not available"):
                 FOAMRuntime()
 
-    def test_forced_docker_with_docker(self):
-        with (
-            patch.dict(os.environ, {"FLOWBOOST_FOAM_MODE": "docker"}, clear=False),
-            patch.object(FOAMRuntime, "_docker_available", return_value=True),
-        ):
-            runtime = FOAMRuntime()
-            assert runtime.mode == FOAMRuntime.Mode.DOCKER
+    def test_forced_docker_with_docker(self, docker_runtime):
+        assert docker_runtime.mode == FOAMRuntime.Mode.DOCKER
 
     def test_auto_falls_to_docker_when_no_foam(self):
         with (
@@ -55,158 +93,503 @@ class TestDetectMode:
             with pytest.raises(RuntimeError, match="OpenFOAM not available"):
                 FOAMRuntime()
 
+    def test_auto_prefers_native_when_both_available(self):
+        with (
+            patch.dict(
+                os.environ,
+                {"FOAM_INST_DIR": "/opt/openfoam", "FLOWBOOST_FOAM_MODE": "auto"},
+            ),
+            patch.object(FOAMRuntime, "_docker_available", return_value=True),
+        ):
+            runtime = FOAMRuntime()
+            assert runtime.mode == FOAMRuntime.Mode.NATIVE
+
+    def test_custom_docker_image_from_env(self):
+        with patch.dict(
+            os.environ,
+            {"FLOWBOOST_FOAM_IMAGE": "custom/foam:latest", "FOAM_INST_DIR": "/opt"},
+        ):
+            runtime = FOAMRuntime()
+            assert runtime._docker_image == "custom/foam:latest"
+
+
+# ---------------------------------------------------------------------------
+# Path translation
+# ---------------------------------------------------------------------------
+
 
 class TestTranslatePath:
-    def test_relative_path_unchanged(self):
-        with patch.dict(os.environ, {"FOAM_INST_DIR": "/opt/openfoam"}):
-            runtime = FOAMRuntime()
-        assert runtime._translate_path("constant/U") == "constant/U"
+    def test_relative_path_unchanged(self, native_runtime):
+        assert native_runtime._translate_path("constant/U") == "constant/U"
 
-    def test_absolute_under_mount(self):
-        with patch.dict(os.environ, {"FOAM_INST_DIR": "/opt/openfoam"}):
-            runtime = FOAMRuntime()
-        runtime.add_mount(Path("/tmp/cases"), "/work")
-        result = runtime._translate_path("/tmp/cases/mycase/0/U")
+    def test_absolute_under_mount(self, native_runtime):
+        native_runtime.add_mount(Path("/tmp/cases"), "/work")
+        result = native_runtime._translate_path("/tmp/cases/mycase/0/U")
         assert result == "/work/mycase/0/U"
 
-    def test_absolute_not_under_mount_passes_through(self):
-        with patch.dict(os.environ, {"FOAM_INST_DIR": "/opt/openfoam"}):
-            runtime = FOAMRuntime()
-        runtime.add_mount(Path("/tmp/cases"), "/work")
-        result = runtime._translate_path("/opt/openfoam/tutorials/X/Y")
+    def test_absolute_not_under_mount_passes_through(self, native_runtime):
+        native_runtime.add_mount(Path("/tmp/cases"), "/work")
+        result = native_runtime._translate_path("/opt/openfoam/tutorials/X/Y")
         assert result == "/opt/openfoam/tutorials/X/Y"
+
+    def test_first_matching_mount_wins(self, native_runtime):
+        native_runtime.add_mount(Path("/tmp/cases"), "/work")
+        native_runtime.add_mount(Path("/tmp/cases/sub"), "/work1")
+        result = native_runtime._translate_path("/tmp/cases/sub/mycase/0/U")
+        assert result == "/work/sub/mycase/0/U"
+
+    def test_second_mount_matches_when_first_doesnt(self, native_runtime):
+        native_runtime.add_mount(Path("/tmp/a"), "/work")
+        native_runtime.add_mount(Path("/tmp/b"), "/work1")
+        result = native_runtime._translate_path("/tmp/b/mycase/0/U")
+        assert result == "/work1/mycase/0/U"
 
 
 class TestTranslateCommand:
-    def test_foam_command_args_translated(self):
-        with patch.dict(os.environ, {"FOAM_INST_DIR": "/opt/openfoam"}):
-            runtime = FOAMRuntime()
-        runtime.add_mount(Path("/tmp/cases"), "/work")
-
+    def test_foam_command_args_translated(self, native_runtime):
+        native_runtime.add_mount(Path("/tmp/cases"), "/work")
         cmd = ["foamDictionary", "/tmp/cases/mycase/constant/U", "-entry", "inlet"]
-        translated_cmd, translated_cwd = runtime._translate_command(cmd, None)
+        translated_cmd, _ = native_runtime._translate_command(cmd, None)
 
-        assert translated_cmd[0] == "foamDictionary"
-        assert translated_cmd[1] == "/work/mycase/constant/U"
-        assert translated_cmd[2] == "-entry"
-        assert translated_cmd[3] == "inlet"
+        assert translated_cmd == [
+            "foamDictionary", "/work/mycase/constant/U", "-entry", "inlet"
+        ]
 
-    def test_cwd_translated(self):
-        with patch.dict(os.environ, {"FOAM_INST_DIR": "/opt/openfoam"}):
-            runtime = FOAMRuntime()
-        runtime.add_mount(Path("/tmp/cases"), "/work")
-
-        _, translated_cwd = runtime._translate_command(
+    def test_cwd_translated(self, native_runtime):
+        native_runtime.add_mount(Path("/tmp/cases"), "/work")
+        _, translated_cwd = native_runtime._translate_command(
             ["listTimes"], Path("/tmp/cases/mycase")
         )
         assert translated_cwd == "/work/mycase"
 
 
-class TestRunRouting:
-    def test_non_foam_command_runs_natively(self):
-        """Non-FOAM commands should bypass Docker even in DOCKER mode."""
-        with (
-            patch.dict(os.environ, {"FLOWBOOST_FOAM_MODE": "docker"}, clear=False),
-            patch.object(FOAMRuntime, "_docker_available", return_value=True),
-        ):
-            runtime = FOAMRuntime()
+# ---------------------------------------------------------------------------
+# Run routing
+# ---------------------------------------------------------------------------
 
-        result = runtime.run(["echo", "hello"])
+
+class TestRunRouting:
+    def test_non_foam_command_runs_natively(self, docker_runtime):
+        result = docker_runtime.run(["echo", "hello"])
         assert result.returncode == 0
         assert "hello" in result.stdout
 
     def test_foam_command_detected(self):
-        """FOAM commands should be recognized by name."""
         assert "foamDictionary" in FOAMRuntime.FOAM_COMMANDS
         assert "foamCloneCase" in FOAMRuntime.FOAM_COMMANDS
         assert "echo" not in FOAMRuntime.FOAM_COMMANDS
 
+    def test_foam_command_via_full_path_detected(self, docker_runtime):
+        with patch.object(docker_runtime, "_docker_exec") as mock_exec:
+            mock_exec.return_value = subprocess.CompletedProcess([], 0, "", "")
+            docker_runtime.run(["/usr/bin/foamDictionary", "constant/U"])
+            mock_exec.assert_called_once()
 
-class TestContainer:
-    def _make_docker_runtime(self):
-        with (
-            patch.dict(os.environ, {"FLOWBOOST_FOAM_MODE": "docker"}, clear=False),
-            patch.object(FOAMRuntime, "_docker_available", return_value=True),
-        ):
-            return FOAMRuntime()
+    def test_foam_command_routes_to_docker_exec(self, docker_runtime):
+        with patch.object(docker_runtime, "_docker_exec") as mock_exec:
+            mock_exec.return_value = subprocess.CompletedProcess([], 0, "", "")
+            docker_runtime.run(["foamDictionary", "constant/U"])
+            mock_exec.assert_called_once_with(
+                ["foamDictionary", "constant/U"], None
+            )
 
-    def test_container_starts_and_stops(self):
-        runtime = self._make_docker_runtime()
-        with (
-            patch.object(runtime, "_ensure_container") as mock_ensure,
-            patch.object(runtime, "_stop_container") as mock_stop,
-            patch.object(runtime, "_ensure_docker_image"),
-        ):
-            with runtime.container():
-                mock_ensure.assert_called_once()
+
+# ---------------------------------------------------------------------------
+# Mount management
+# ---------------------------------------------------------------------------
+
+
+class TestAddMount:
+    def test_after_container_start_raises(self, native_runtime):
+        native_runtime._container_id = "abc123"
+        with pytest.raises(RuntimeError, match="Cannot add mounts"):
+            native_runtime.add_mount(Path("/tmp/data"))
+
+    def test_duplicate_guest_path_raises(self, native_runtime):
+        native_runtime.add_mount(Path("/tmp/a"), "/work")
+        with pytest.raises(RuntimeError, match="already in use"):
+            native_runtime.add_mount(Path("/tmp/b"), "/work")
+
+    def test_different_guest_paths_allowed(self, native_runtime):
+        native_runtime.add_mount(Path("/tmp/a"), "/work")
+        native_runtime.add_mount(Path("/tmp/b"), "/work1")
+        assert len(native_runtime._mounts) == 2
+
+
+class TestIsMounted:
+    def test_path_under_mount(self, native_runtime):
+        native_runtime._mounts = [(Path("/tmp/cases").resolve(), "/work")]
+        assert native_runtime._is_mounted(Path("/tmp/cases/sub/dir"))
+
+    def test_path_not_under_any_mount(self, native_runtime):
+        native_runtime._mounts = [(Path("/tmp/cases").resolve(), "/work")]
+        assert not native_runtime._is_mounted(Path("/var/data"))
+
+    def test_exact_mount_root_is_mounted(self, native_runtime):
+        mount_root = Path("/tmp/cases").resolve()
+        native_runtime._mounts = [(mount_root, "/work")]
+        assert native_runtime._is_mounted(Path("/tmp/cases"))
+
+    def test_symlinked_path_resolves(self, native_runtime, tmp_path):
+        real_dir = tmp_path / "real"
+        real_dir.mkdir()
+        link = tmp_path / "link"
+        link.symlink_to(real_dir)
+
+        native_runtime._mounts = [(tmp_path.resolve(), "/work")]
+        assert native_runtime._is_mounted(link)
+
+
+# ---------------------------------------------------------------------------
+# Auto-mount
+# ---------------------------------------------------------------------------
+
+
+class TestAutoMount:
+    def test_discovers_host_path_from_command_arg(self, docker_runtime, tmp_path):
+        case_dir = tmp_path / "cases" / "mycase"
+        case_dir.mkdir(parents=True)
+        u_file = case_dir / "0" / "U"
+        u_file.parent.mkdir()
+        u_file.touch()
+
+        docker_runtime._auto_mount(["foamDictionary", str(u_file)], None)
+
+        assert len(docker_runtime._mounts) == 1
+        host_root, guest_path = docker_runtime._mounts[0]
+        assert u_file.parent.resolve().is_relative_to(host_root)
+        assert guest_path == "/work"
+
+    def test_discovers_cwd(self, docker_runtime, tmp_path):
+        case_dir = tmp_path / "cases" / "mycase"
+        case_dir.mkdir(parents=True)
+
+        docker_runtime._auto_mount(["foamCleanCase"], case_dir)
+
+        assert len(docker_runtime._mounts) == 1
+        host_root, _ = docker_runtime._mounts[0]
+        assert case_dir.resolve().is_relative_to(host_root)
+
+    def test_skips_nonexistent_host_paths(self, docker_runtime):
+        docker_runtime._auto_mount(
+            ["foamDictionary", "/opt/openfoam13/tutorials/cavity/0/U"], None
+        )
+        assert len(docker_runtime._mounts) == 0
+
+    def test_skips_already_covered_paths(self, docker_runtime, tmp_path):
+        docker_runtime._mounts = [(tmp_path.resolve(), "/work")]
+        subdir = tmp_path / "case_0"
+        subdir.mkdir()
+
+        docker_runtime._auto_mount(["foamCleanCase"], subdir)
+        assert len(docker_runtime._mounts) == 1
+
+    def test_finds_common_ancestor(self, docker_runtime, tmp_path):
+        case_a = tmp_path / "cases" / "a" / "0"
+        case_b = tmp_path / "cases" / "b" / "0"
+        case_a.mkdir(parents=True)
+        case_b.mkdir(parents=True)
+        (case_a / "U").touch()
+        (case_b / "U").touch()
+
+        docker_runtime._auto_mount(
+            ["foamDictionary", str(case_a / "U"), str(case_b / "U")], None
+        )
+
+        assert len(docker_runtime._mounts) == 1
+        host_root, _ = docker_runtime._mounts[0]
+        assert case_a.resolve().is_relative_to(host_root)
+        assert case_b.resolve().is_relative_to(host_root)
+
+    def test_raises_when_common_ancestor_too_broad(self, docker_runtime):
+        with patch.object(docker_runtime, "_is_mounted", return_value=False):
+            with pytest.raises(RuntimeError, match="too broad"):
+                docker_runtime._auto_mount(
+                    ["foamDictionary", "/tmp/x", "/var/y"], None
+                )
+
+    def test_guest_path_increments(self, docker_runtime, tmp_path):
+        docker_runtime._mounts = [(Path("/existing"), "/work")]
+        case_dir = tmp_path / "cases"
+        case_dir.mkdir()
+
+        docker_runtime._auto_mount(["foamCleanCase"], case_dir)
+        assert len(docker_runtime._mounts) == 2
+        _, guest = docker_runtime._mounts[1]
+        assert guest == "/work1"
+
+    def test_restarts_container_for_new_mount(self, docker_runtime, tmp_path):
+        docker_runtime._container_id = "existing_container"
+        case_dir = tmp_path / "newcases"
+        case_dir.mkdir()
+
+        with patch.object(docker_runtime, "_stop_container") as mock_stop:
+            docker_runtime._auto_mount(["foamCleanCase"], case_dir)
             mock_stop.assert_called_once()
 
-    def test_container_registers_mounts(self):
-        runtime = self._make_docker_runtime()
+
+# ---------------------------------------------------------------------------
+# Docker exec
+# ---------------------------------------------------------------------------
+
+
+class TestDockerExec:
+    def test_shell_command_properly_quoted(self, docker_runtime, tmp_path):
+        docker_runtime._container_id = "test_container"
+        docker_runtime._mounts = [(tmp_path.resolve(), "/work")]
+        case_dir = tmp_path / "my case"
+        case_dir.mkdir()
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess([], 0, "", "")
+            docker_runtime._docker_exec(["foamCleanCase"], case_dir)
+
+            args = mock_run.call_args[0][0]
+            assert args[:3] == ["docker", "exec", "test_container"]
+            assert args[3:5] == ["bash", "-c"]
+            shell_cmd = args[5]
+            assert "cd" in shell_cmd
+            assert "foamCleanCase" in shell_cmd
+
+
+# ---------------------------------------------------------------------------
+# Container context manager
+# ---------------------------------------------------------------------------
+
+
+class TestContainer:
+    def test_starts_and_stops(self, docker_runtime_no_lifecycle):
+        rt = docker_runtime_no_lifecycle
+        with rt.container():
+            rt._ensure_container.assert_called_once()
+        rt._stop_container.assert_called_once()
+
+    def test_registers_mounts(self, docker_runtime_no_lifecycle):
+        rt = docker_runtime_no_lifecycle
         mount_a = Path("/tmp/work_a")
         mount_b = Path("/tmp/work_b")
 
-        with (
-            patch.object(runtime, "_ensure_container"),
-            patch.object(runtime, "_stop_container"),
-        ):
-            with runtime.container(mount_a, mount_b):
-                assert len(runtime._mounts) == 2
-                host_roots = [m[0] for m in runtime._mounts]
-                assert mount_a.resolve() in host_roots
-                assert mount_b.resolve() in host_roots
+        with rt.container(mount_a, mount_b):
+            assert len(rt._mounts) == 2
+            host_roots = [m[0] for m in rt._mounts]
+            assert mount_a.resolve() in host_roots
+            assert mount_b.resolve() in host_roots
 
-    def test_container_noop_in_native_mode(self):
-        with patch.dict(os.environ, {"FOAM_INST_DIR": "/opt/openfoam"}):
-            runtime = FOAMRuntime()
-
+    def test_noop_in_native_mode(self, native_runtime):
         with (
-            patch.object(runtime, "_ensure_container") as mock_ensure,
-            patch.object(runtime, "_stop_container") as mock_stop,
+            patch.object(native_runtime, "_ensure_container") as mock_ensure,
+            patch.object(native_runtime, "_stop_container") as mock_stop,
         ):
-            with runtime.container() as rt:
-                assert rt is runtime
+            with native_runtime.container() as rt:
+                assert rt is native_runtime
                 mock_ensure.assert_not_called()
             mock_stop.assert_called_once()
 
-    def test_container_stops_on_exception(self):
-        runtime = self._make_docker_runtime()
+    def test_stops_on_exception(self, docker_runtime_no_lifecycle):
+        rt = docker_runtime_no_lifecycle
+        with pytest.raises(ValueError):
+            with rt.container():
+                raise ValueError("boom")
+        rt._stop_container.assert_called_once()
+
+    def test_restores_mounts_on_exit(self, docker_runtime_no_lifecycle):
+        rt = docker_runtime_no_lifecycle
+        rt._mounts = [(Path("/existing"), "/work")]
+
+        with rt.container(Path("/tmp/new")):
+            assert len(rt._mounts) == 2
+        assert len(rt._mounts) == 1
+        assert rt._mounts[0] == (Path("/existing"), "/work")
+
+    def test_restores_mounts_on_exception(self, docker_runtime_no_lifecycle):
+        rt = docker_runtime_no_lifecycle
+        rt._mounts = [(Path("/existing"), "/work")]
+
+        with pytest.raises(ValueError):
+            with rt.container(Path("/tmp/new")):
+                assert len(rt._mounts) == 2
+                raise ValueError("boom")
+        assert len(rt._mounts) == 1
+        assert rt._mounts[0] == (Path("/existing"), "/work")
+
+    def test_nested_raises(self, docker_runtime_no_lifecycle):
+        rt = docker_runtime_no_lifecycle
+        with rt.container():
+            with pytest.raises(RuntimeError, match="not re-entrant"):
+                with rt.container():
+                    pass
+
+    def test_sequential_allowed(self, docker_runtime_no_lifecycle):
+        rt = docker_runtime_no_lifecycle
+        with rt.container():
+            pass
+        with rt.container():
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Container lifecycle internals
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureContainer:
+    def test_atexit_registered_only_once(self, docker_runtime):
+        create_result = subprocess.CompletedProcess([], 0, "cid\n", "")
+        start_result = subprocess.CompletedProcess([], 0, "", "")
+
         with (
-            patch.object(runtime, "_ensure_container"),
-            patch.object(runtime, "_stop_container") as mock_stop,
+            patch.object(docker_runtime, "_ensure_docker_image"),
+            patch("subprocess.run") as mock_run,
+            patch("atexit.register") as mock_atexit,
         ):
-            with pytest.raises(ValueError):
-                with runtime.container():
-                    raise ValueError("boom")
-            mock_stop.assert_called_once()
+            mock_run.side_effect = [create_result, start_result]
+            docker_runtime._ensure_container()
+            assert mock_atexit.call_count == 1
 
-    def test_container_restores_mounts_on_exit(self):
-        runtime = self._make_docker_runtime()
-        runtime._mounts = [(Path("/existing"), "/work")]
+            # Stop and recreate — atexit should not be called again
+            docker_runtime._container_id = None
+            mock_run.side_effect = [create_result, start_result]
+            docker_runtime._ensure_container()
+            assert mock_atexit.call_count == 1
+
+    def test_cleans_up_on_start_failure(self, docker_runtime):
+        create_result = subprocess.CompletedProcess([], 0, "container_id\n", "")
+        start_result = subprocess.CompletedProcess([], 1, "", "start failed")
+        rm_result = subprocess.CompletedProcess([], 0, "", "")
 
         with (
-            patch.object(runtime, "_ensure_container"),
-            patch.object(runtime, "_stop_container"),
+            patch.object(docker_runtime, "_ensure_docker_image"),
+            patch("subprocess.run") as mock_run,
         ):
-            with runtime.container(Path("/tmp/new")):
-                assert len(runtime._mounts) == 2
-            assert len(runtime._mounts) == 1
-            assert runtime._mounts[0] == (Path("/existing"), "/work")
+            mock_run.side_effect = [create_result, start_result, rm_result]
+            with pytest.raises(RuntimeError, match="Failed to start"):
+                docker_runtime._ensure_container()
 
-    def test_container_restores_mounts_on_exception(self):
-        runtime = self._make_docker_runtime()
-        runtime._mounts = [(Path("/existing"), "/work")]
+            rm_call = mock_run.call_args_list[2]
+            assert rm_call[0][0] == ["docker", "rm", "container_id"]
+            assert docker_runtime._container_id is None
 
+    def test_skips_if_already_running(self, docker_runtime):
+        docker_runtime._container_id = "already_running"
+        with patch.object(docker_runtime, "_ensure_docker_image") as mock_image:
+            docker_runtime._ensure_container()
+            mock_image.assert_not_called()
+
+
+class TestStopContainer:
+    def test_noop_when_no_container(self, docker_runtime):
+        docker_runtime._stop_container()  # should not raise
+
+    def test_clears_container_id(self, docker_runtime):
+        docker_runtime._container_id = "test_id"
+        with patch("subprocess.run"):
+            docker_runtime._stop_container()
+        assert docker_runtime._container_id is None
+
+    def test_force_kills_on_stop_timeout(self, docker_runtime):
+        docker_runtime._container_id = "test_id"
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                subprocess.TimeoutExpired("docker stop", 15),
+                subprocess.CompletedProcess([], 0, "", ""),
+            ]
+            docker_runtime._stop_container()
+
+        assert docker_runtime._container_id is None
+        kill_call = mock_run.call_args_list[1]
+        assert "kill" in kill_call[0][0]
+
+    def test_never_raises_on_double_timeout(self, docker_runtime):
+        docker_runtime._container_id = "test_id"
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                subprocess.TimeoutExpired("docker stop", 15),
+                subprocess.TimeoutExpired("docker kill", 10),
+            ]
+            docker_runtime._stop_container()
+        assert docker_runtime._container_id is None
+
+    def test_never_raises_on_oserror(self, docker_runtime):
+        docker_runtime._container_id = "test_id"
+        with patch("subprocess.run", side_effect=OSError("docker not found")):
+            docker_runtime._stop_container()
+        assert docker_runtime._container_id is None
+
+
+class TestEnsureDockerImage:
+    def test_skips_build_when_image_exists(self, docker_runtime):
         with (
-            patch.object(runtime, "_ensure_container"),
-            patch.object(runtime, "_stop_container"),
+            patch.object(docker_runtime, "_docker_image_available", return_value=True),
+            patch("subprocess.run") as mock_run,
         ):
-            with pytest.raises(ValueError):
-                with runtime.container(Path("/tmp/new")):
-                    assert len(runtime._mounts) == 2
-                    raise ValueError("boom")
-            assert len(runtime._mounts) == 1
-            assert runtime._mounts[0] == (Path("/existing"), "/work")
+            docker_runtime._ensure_docker_image()
+            mock_run.assert_not_called()
+
+    def test_raises_when_no_image_and_no_dockerfile(self, docker_runtime):
+        with (
+            patch.object(docker_runtime, "_docker_image_available", return_value=False),
+            patch("flowboost.openfoam.runtime.DOCKERFILE_DIR", Path("/nonexistent")),
+        ):
+            with pytest.raises(RuntimeError, match="not found"):
+                docker_runtime._ensure_docker_image()
+
+    def test_raises_on_build_failure(self, docker_runtime, tmp_path):
+        with (
+            patch.object(docker_runtime, "_docker_image_available", return_value=False),
+            patch("flowboost.openfoam.runtime.DOCKERFILE_DIR", tmp_path),
+            patch("subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = subprocess.CompletedProcess(
+                [], 1, "", "build error details"
+            )
+            with pytest.raises(RuntimeError, match="build error details"):
+                docker_runtime._ensure_docker_image()
+
+
+# ---------------------------------------------------------------------------
+# File transfer & FOAM queries
+# ---------------------------------------------------------------------------
+
+
+class TestTransferFile:
+    def test_native_mode_copies_file(self, native_runtime, tmp_path):
+        src = tmp_path / "source.txt"
+        src.write_text("hello")
+        dst = tmp_path / "dest.txt"
+
+        native_runtime.transfer_file(str(src), dst)
+        assert dst.read_text() == "hello"
+
+    def test_docker_mode_raises_on_failure(self, docker_runtime):
+        docker_runtime._container_id = "test_container"
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                [], 1, "", "no such file"
+            )
+            with pytest.raises(RuntimeError, match="Failed to transfer"):
+                docker_runtime.transfer_file("/container/path", Path("/local/path"))
+
+
+class TestFoamTutorialsPath:
+    def test_raises_in_native_mode(self, native_runtime):
+        with pytest.raises(RuntimeError, match="native mode"):
+            native_runtime._foam_tutorials_path()
+
+    def test_caches_result(self, docker_runtime):
+        docker_runtime._container_id = "test_container"
+        result = subprocess.CompletedProcess([], 0, "/opt/openfoam/tutorials\n", "")
+
+        with patch("subprocess.run", return_value=result) as mock_run:
+            path1 = docker_runtime._foam_tutorials_path()
+            path2 = docker_runtime._foam_tutorials_path()
+
+        assert path1 == path2 == "/opt/openfoam/tutorials"
+        mock_run.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Singleton
+# ---------------------------------------------------------------------------
 
 
 class TestSingleton:
@@ -223,7 +606,7 @@ class TestSingleton:
         finally:
             rt._runtime = saved
 
-    def test_reset_runtime_clears(self):
+    def test_reset_runtime_clears_and_cleans_up(self):
         import flowboost.openfoam.runtime as rt
 
         saved = rt._runtime
@@ -231,9 +614,10 @@ class TestSingleton:
         try:
             with patch.dict(os.environ, {"FOAM_INST_DIR": "/opt/openfoam"}):
                 r1 = get_runtime()
-                # Use module-level assignment instead of reset_runtime()
-                # to avoid stopping a real container
-                rt._runtime = None
+                with patch.object(r1, "cleanup") as mock_cleanup:
+                    reset_runtime()
+                    mock_cleanup.assert_called_once()
+                assert rt._runtime is None
                 r2 = get_runtime()
                 assert r1 is not r2
         finally:

--- a/tests/flowboost/optimizer/test_backend.py
+++ b/tests/flowboost/optimizer/test_backend.py
@@ -59,7 +59,8 @@ def test_tell(Ax_backend, test_case, foam_in_env):
     obj = Ax_backend.objectives[0]
 
     # Run evaluation for objective
-    out = obj.batch_process(cases=[test_case])
+    outputs = obj.batch_evaluate(cases=[test_case])
+    out = obj.batch_post_process(cases=[test_case], outputs=outputs)
     logging.info(f"Batch-processed: {out}")
 
     # Initialize backend

--- a/tests/flowboost/session/test_session.py
+++ b/tests/flowboost/session/test_session.py
@@ -42,7 +42,7 @@ def test_incorrect_startup():
     pass
 
 
-def test_simple_blank_start(foam_in_env):
+def test_simple_blank_start(foam_in_env, tmp_path, monkeypatch):
     # Add objective function
     objective = Objective(
         name="test_objective", minimize=True, objective_function=lambda x: 1
@@ -58,7 +58,7 @@ def test_simple_blank_start(foam_in_env):
 
     session = Session(
         name="My cool optimization campaign",
-        data_dir=Path("~/test_campaign_flowboost").expanduser(),
+        data_dir=tmp_path / "test_campaign_flowboost",
         dataframe_format="polars",
     )
 
@@ -72,6 +72,9 @@ def test_simple_blank_start(foam_in_env):
     )
 
     session.attach_template_case(aachen_case)
+
+    # session.start() prompts for number of cases when no job manager is set
+    monkeypatch.setattr("builtins.input", lambda _: "2")
     new_cases = session.start()
 
     assert new_cases, "Optimizer did not provide new cases"
@@ -82,4 +85,4 @@ def test_simple_blank_start(foam_in_env):
     for i, out in enumerate(output, 1):
         print(f"[{i}] {out}")
 
-    # session._delete_all_data()
+    session._delete_all_data()


### PR DESCRIPTION
## Summary

- **`FOAMRuntime`**: transparently routes OpenFOAM CLI commands through Docker when no native install is available. A persistent container is started on first use and reused via `docker exec`.
- **`container(*mounts)`**: context manager for scoped container lifecycle with pre-registered mounts, avoiding container restarts when iterating over case directories.
- **`DockerLocal` manager**: runs simulations in per-job Docker containers, complementing the existing Local/SGE/Slurm managers.
- **Auto-mount**: discovers host paths from command args and mounts their common ancestor into the container.

60 runtime tests, 11 DockerLocal tests (all mocked — no Docker or OpenFOAM needed in CI).

## Test plan

- [x] `uv run pytest tests/flowboost/openfoam/test_runtime.py` — 60 pass
- [x] `uv run pytest tests/flowboost/manager/test_docker_local.py` — 11 pass
- [ ] CI