### PR TITLE
Coerce types in Case.parametrize_configuration()

### DIFF
--- a/flowboost/openfoam/case.py
+++ b/flowboost/openfoam/case.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     from flowboost.optimizer.objectives import AggregateObjective, Objective
 
 DEFAULT_METADATA: str = "metadata.toml"
+GENERATION_INDEX_SORT_SENTINEL: str = "99999.99"
 
 
 class Status(Enum):
@@ -358,58 +359,67 @@ class Case:
 
         return read_from.reader(self.path)
 
-        raise ValueError("No DictionaryLink or path provided, cannot produce a reader")
-
     def parametrize_configuration(self, dimensions: list[Dimension]) -> dict[str, Any]:
         """
-        Parametrize a case configuration for the given list of dimensions. More
-        specifically, the function produces a dictionary mapping the name of
-        each dimension to the value of the linked entry in the case's config
-        dictionary.
+        Produce a dictionary mapping each dimension's name to its current
+        value in this case, coerced to the dimension's declared Python type.
+
+        Values are read from saved optimizer-suggestion metadata when
+        available, falling back to the linked OpenFOAM dictionary entry.
 
         Args:
-            dimensions (list[Dimension]): List of dimensions to produce \
-                parametrization for
+            dimensions (list[Dimension]): Dimensions to parametrize.
 
         Raises:
-            ValueError: On failure of dictionary reading
+            ValueError: On failure of dictionary reading or type coercion.
 
         Returns:
-            dict[str, Any]: Parametrized configuration keyed by dimension names
+            dict[str, Any]: Parametrized configuration keyed by dimension names.
         """
-        par_dict = {}
-
-        # Try to read from metadata first (for completed cases)
         metadata = self.read_metadata()
-        optimizer_suggestions = (
-            metadata.get("optimizer-suggestion", {}) if metadata else {}
-        )
+        suggestions = metadata.get("optimizer-suggestion", {}) if metadata else {}
 
+        par_dict = {}
         for dim in dimensions:
-            # First try to get from saved optimizer-suggestion metadata
-            if dim.name in optimizer_suggestions:
-                value = optimizer_suggestions[dim.name].get("value")
-                if value is not None:
-                    par_dict[dim.name] = value
-                    logging.debug(f"Read dim='{dim.name}' from metadata: {value}")
-                    continue
+            # Read raw value: prefer saved metadata, fall back to dictionary
+            raw = self._read_dimension_value(dim, suggestions)
 
-            # Otherwise, read from dictionary
-            if dim.linked_entry is None:
+            # Coerce to the dimension's declared type
+            try:
+                par_dict[dim.name] = dim.coerce_value(raw)
+            except (ValueError, TypeError) as exc:
                 raise ValueError(
-                    f"Cannot parametrize case: '{dim.name}' has no linked dict entry"
-                )
-
-            reader = dim.linked_entry.reader(self.path)
-
-            if not reader or isinstance(reader, DictionaryReader):
-                raise ValueError(
-                    f"Cannot parametrize case: no value for {reader} [{self}]"
-                )
-
-            par_dict[dim.name] = reader.value
+                    f"Cannot coerce dim='{dim.name}' value {raw!r} "
+                    f"to {dim.value_type} [{self}]"
+                ) from exc
 
         return par_dict
+
+    def _read_dimension_value(self, dim: Dimension, suggestions: dict) -> Any:
+        """Return the raw value for *dim* from metadata or the linked dictionary."""
+        # Try saved optimizer-suggestion metadata first (for completed cases)
+        suggestion = suggestions.get(dim.name, {})
+        if isinstance(suggestion, dict):
+            value = suggestion.get("value")
+            if value is not None:
+                logging.debug(f"Read dim='{dim.name}' from metadata: {value}")
+                return value
+
+        # Fall back to the linked dictionary entry
+        if dim.linked_entry is None:
+            raise ValueError(
+                f"Cannot parametrize case: '{dim.name}' has no linked dict entry"
+            )
+
+        entry = dim.linked_entry.reader(self.path)
+
+        if not isinstance(entry, Entry):
+            raise ValueError(
+                f"Cannot parametrize case: expected Entry for "
+                f"'{dim.name}', got {type(entry).__name__} [{self}]"
+            )
+
+        return entry.value
 
     def objective_function_outputs(
         self, objectives: list[Union["Objective", "AggregateObjective"]]

--- a/flowboost/optimizer/interfaces/Ax.py
+++ b/flowboost/optimizer/interfaces/Ax.py
@@ -50,7 +50,9 @@ class AxBackend(Backend):
         self._verify_configuration()
 
         # Compute remaining initialization trials, accounting for already-completed ones
-        base_init = self.initialization_trials if self.initialization_trials is not None else 5
+        base_init = (
+            self.initialization_trials if self.initialization_trials is not None else 5
+        )
         remaining_init = max(0, base_init - num_already_completed)
 
         logging.info(
@@ -210,6 +212,7 @@ class AxBackend(Backend):
             raise ValueError("Re-initialize should not be called when stateless=False")
         self.client = AxClient()
         num_completed = len(self._trial_index_case_mapping)
+        self._trial_index_case_mapping = {}
         self.initialize(num_already_completed=num_completed)
 
     def set_objectives(self, objectives: list[Union[Objective, AggregateObjective]]):
@@ -422,32 +425,12 @@ class AxBackend(Backend):
                 logging.info(f"Case already attached in _ensure_attached, {case}")
                 continue
 
-            # Generate parametrizations: these describe the search space for Ax
+            # Generate parametrizations: these describe the search space for Ax.
+            # Type coercion is handled by Case.parametrize_configuration().
             p = case.parametrize_configuration(self.dimensions)
 
-            # TODO: report this to Ax issue tracker
-            # Convert types to match Ax search space expectations
-            p_typed = {}
-            for dim in self.dimensions:
-                value = p[dim.name]
-
-                # Convert to the proper type based on dimension's value_type
-                if dim.value_type == "int":
-                    p_typed[dim.name] = int(float(value))
-                elif dim.value_type == "float":
-                    p_typed[dim.name] = float(value)
-                elif dim.value_type == "bool":
-                    p_typed[dim.name] = bool(value)
-                else:
-                    p_typed[dim.name] = str(value)
-
-                logging.debug(
-                    f"Converted {dim.name}: {value} ({type(value).__name__}) "
-                    f"-> {p_typed[dim.name]} ({type(p_typed[dim.name]).__name__})"
-                )
-
-            logging.info(f"Attaching c={case.name}, p={p_typed}")
-            _, idx = self.client.attach_trial(parameters=p_typed, arm_name=case.name)
+            logging.info(f"Attaching c={case.name}, p={p}")
+            _, idx = self.client.attach_trial(parameters=p, arm_name=case.name)
 
             # TODO if we were to run in stateful mode, we'd stash the index
             self._trial_index_case_mapping[case] = idx

--- a/flowboost/optimizer/search_space.py
+++ b/flowboost/optimizer/search_space.py
@@ -36,7 +36,7 @@ class Dimension:
             relative path is available.
         """
         self.linked_entry = dictionary_link
-        logging.info(f"Linked dim='{self.name}' to {DictionaryLink}")
+        logging.info(f"Linked dim='{self.name}' to {dictionary_link}")
 
     @classmethod
     def range(
@@ -131,17 +131,68 @@ class Dimension:
             logging.error(f"Cannot convert {value} to {target_type}.")
             raise
 
+    # Canonical mapping between Python types and their string representations.
+    # Used by _get_value_type_str (type→str) and coerce (str→type).
+    _TYPE_MAP: dict[type, str] = {int: "int", float: "float", bool: "bool", str: "str"}
+    _TYPE_MAP_INV: dict[str, type] = {v: k for k, v in _TYPE_MAP.items()}
+
     @staticmethod
     def _get_value_type_str(value_type: Type) -> str:
         """
         Converts a type (e.g., int, float, bool, str) to its string representation.
         """
-        type_map = {int: "int", float: "float", bool: "bool", str: "str"}
+        if value_type in Dimension._TYPE_MAP:
+            return Dimension._TYPE_MAP[value_type]
 
-        # Check if the value_type is in the type_map and return its string repr
-        if value_type in type_map:
-            return type_map[value_type]
-        else:
-            raise ValueError(
-                f"Unsupported type {value_type}, must be (int, float, bool, str)"
-            )
+        raise ValueError(
+            f"Unsupported type {value_type}, must be (int, float, bool, str)"
+        )
+
+    def coerce_value(self, value: Any) -> Any:
+        """Coerce *value* to this dimension's declared ``value_type``.
+
+        Returns *value* unchanged when ``value_type`` is ``None``.
+        """
+        if self.value_type is None:
+            return value
+        return Dimension._coerce(value, self.value_type)
+
+    @staticmethod
+    def _coerce(value: Any, value_type: str) -> Any:
+        """Coerce *value* to the Python type indicated by *value_type*.
+
+        Handles the quirks that arise when values are read back from
+        OpenFOAM dictionaries or TOML metadata (strings, numpy scalars,
+        ``bool`` being a subclass of ``int``, etc.).
+
+        Args:
+            value: The raw value to coerce.
+            value_type: One of ``"int"``, ``"float"``, ``"bool"``, ``"str"``.
+
+        Returns:
+            The value converted to the corresponding Python native type.
+
+        Raises:
+            ValueError: If *value_type* is unknown or conversion fails.
+        """
+        target = Dimension._TYPE_MAP_INV.get(value_type)
+        if target is None:
+            raise ValueError(f"Unknown value_type: {value_type!r}")
+
+        # Exact type match — skip conversion.
+        # NOTE: ``isinstance`` is intentionally avoided because
+        # ``isinstance(True, int)`` is True in Python.
+        if type(value) is target:
+            return value
+
+        if target is int:
+            # int(float(v)) handles string integers ("3") and float→int
+            coerced = int(float(value))
+            if float(value) != coerced:
+                logging.warning(f"Lossy int coercion: {value!r} truncated to {coerced}")
+            return coerced
+
+        if target is bool:
+            return Dimension._ensure_types_match(value, bool)
+
+        return target(value)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flowboost"
-version = "0.2.3"
+version = "0.2.4"
 description = "Multi-objective Bayesian optimization library for OpenFOAM"
 license = "Apache-2.0"
 authors = [

--- a/tests/flowboost/optimizer/test_search_space.py
+++ b/tests/flowboost/optimizer/test_search_space.py
@@ -1,0 +1,144 @@
+"""Tests for Dimension type coercion logic."""
+
+import numpy as np
+import pytest
+
+from flowboost.openfoam.dictionary import DictionaryLink
+from flowboost.optimizer.search_space import Dimension
+
+
+# Minimal DictionaryLink for constructing Dimension instances in tests
+def _dummy_link() -> DictionaryLink:
+    return DictionaryLink("system/controlDict").entry("dummy")
+
+
+class TestDimensionCoerce:
+    """Tests for Dimension._coerce() — the static coercion method."""
+
+    # --- int coercion ---
+
+    def test_int_from_string(self):
+        assert Dimension._coerce("3", "int") == 3
+        assert type(Dimension._coerce("3", "int")) is int
+
+    def test_int_from_float(self):
+        assert Dimension._coerce(3.0, "int") == 3
+        assert type(Dimension._coerce(3.0, "int")) is int
+
+    def test_int_from_string_float(self):
+        """String '3.0' should coerce to int 3."""
+        assert Dimension._coerce("3.0", "int") == 3
+        assert type(Dimension._coerce("3.0", "int")) is int
+
+    def test_int_from_bool(self):
+        """bool is a subclass of int; _coerce(True, 'int') must return int, not bool."""
+        result = Dimension._coerce(True, "int")
+        assert result == 1
+        assert type(result) is int  # not bool!
+
+    def test_int_already_int(self):
+        assert Dimension._coerce(42, "int") == 42
+        assert type(Dimension._coerce(42, "int")) is int
+
+    def test_int_lossy_truncation_warns(self, caplog):
+        """Truncating 3.7 → 3 should log a warning."""
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            result = Dimension._coerce(3.7, "int")
+        assert result == 3
+        assert "Lossy" in caplog.text
+
+    def test_int_from_numpy_int(self):
+        result = Dimension._coerce(np.int64(5), "int")
+        assert result == 5
+        assert type(result) is int
+
+    def test_int_from_numpy_float(self):
+        result = Dimension._coerce(np.float64(5.0), "int")
+        assert result == 5
+        assert type(result) is int
+
+    # --- float coercion ---
+
+    def test_float_from_string(self):
+        assert Dimension._coerce("3.14", "float") == 3.14
+        assert type(Dimension._coerce("3.14", "float")) is float
+
+    def test_float_from_int(self):
+        assert Dimension._coerce(3, "float") == 3.0
+        assert type(Dimension._coerce(3, "float")) is float
+
+    def test_float_already_float(self):
+        assert Dimension._coerce(3.14, "float") is not None
+        assert type(Dimension._coerce(3.14, "float")) is float
+
+    def test_float_from_numpy_float(self):
+        result = Dimension._coerce(np.float64(2.718), "float")
+        assert result == pytest.approx(2.718)
+        assert type(result) is float
+
+    # --- bool coercion ---
+
+    def test_bool_from_string_true(self):
+        for s in ("true", "True", "TRUE", "1", "t", "y", "yes"):
+            assert Dimension._coerce(s, "bool") is True
+
+    def test_bool_from_string_false(self):
+        for s in ("false", "False", "0", "no", "n"):
+            assert Dimension._coerce(s, "bool") is False
+
+    def test_bool_already_bool(self):
+        assert Dimension._coerce(True, "bool") is True
+        assert Dimension._coerce(False, "bool") is False
+
+    # --- str coercion ---
+
+    def test_str_from_int(self):
+        assert Dimension._coerce(42, "str") == "42"
+        assert type(Dimension._coerce(42, "str")) is str
+
+    def test_str_from_float(self):
+        result = Dimension._coerce(3.14, "str")
+        assert type(result) is str
+
+    def test_str_already_str(self):
+        assert Dimension._coerce("hello", "str") == "hello"
+
+    # --- error cases ---
+
+    def test_unknown_value_type_raises(self):
+        with pytest.raises(ValueError, match="Unknown value_type"):
+            Dimension._coerce(42, "complex")
+
+    def test_unconvertible_value_raises(self):
+        with pytest.raises((ValueError, TypeError)):
+            Dimension._coerce("not_a_number", "float")
+
+
+class TestDimensionCoerceValue:
+    """Tests for the instance method dim.coerce_value()."""
+
+    def test_coerce_value_uses_dimension_value_type(self):
+        dim = Dimension.range("x", _dummy_link(), 0, 10, dtype=int)
+        assert dim.value_type == "int"
+        result = dim.coerce_value("5")
+        assert result == 5
+        assert type(result) is int
+
+    def test_coerce_value_float(self):
+        dim = Dimension.range("x", _dummy_link(), 0.0, 10.0, dtype=float)
+        result = dim.coerce_value("3.14")
+        assert result == pytest.approx(3.14)
+        assert type(result) is float
+
+    def test_coerce_value_passthrough_when_no_value_type(self):
+        dim = Dimension("x", "range")
+        assert dim.value_type is None
+        raw = "untouched"
+        assert dim.coerce_value(raw) is raw
+
+    def test_coerce_value_choice_str(self):
+        dim = Dimension.choice("s", _dummy_link(), ["a", "b", "c"])
+        assert dim.value_type == "str"
+        assert dim.coerce_value(42) == "42"

--- a/uv.lock
+++ b/uv.lock
@@ -841,7 +841,7 @@ wheels = [
 
 [[package]]
 name = "flowboost"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "ax-platform", version = "1.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
Moves type coercion from `AxBackend._ensure_attached()` into `Case.parametrize_configuration()` so all backends receive natively typed parameters. Adds `Dimension.coerce_value()` with proper handling for `bool`-subclassing-`int`, numpy scalars, and lossy truncation warnings.

Closes #9