### PR TITLE
Fix scalar objective output coercion

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,33 @@ df = case.data.simple_function_object_reader("forceCoeffsCompressible")
 ```
 
 ## Installation
+
 FlowBoost requires Python 3.10 or later.
 
+It is **highly** recommended that you use a virtual environment ("venv") when using FlowBoost. For this, [uv](https://github.com/astral-sh/uv) is the recommended choice, but virtualenv, Poetry, and others will work just fine, too.
+
+To set up a virtual environment using uv:
+
+```shell
+mkdir my-research-dir
+cd my-research-dir
+
+uv sync --python=3.13 # or your desired Python version (>=3.10)
+uv add flowboost # add FlowBoost to the uv-managed venv as a dependency
+```
+
+Next, either source the environment manually using `source .venv/bin/activate`, or run your script using `uv run my_experiment.py`.
+
 ### uv (recommended)
+
+To add FlowBoost to an existing Python environment:
+
 ```shell
 uv add flowboost
 ```
 
 ### pip
+
 ```shell
 pip install flowboost
 ```

--- a/flowboost/openfoam/case.py
+++ b/flowboost/openfoam/case.py
@@ -17,6 +17,7 @@ from flowboost.openfoam.data import Data
 from flowboost.openfoam.dictionary import DictionaryLink, DictionaryReader, Entry
 from flowboost.openfoam.interface import FOAM, run_command
 from flowboost.openfoam.runtime import FOAMRuntime, get_runtime
+from flowboost.optimizer.scalars import coerce_objective_scalar
 from flowboost.optimizer.search_space import Dimension
 
 if TYPE_CHECKING:
@@ -423,23 +424,26 @@ class Case:
 
     def objective_function_outputs(
         self, objectives: list[Union["Objective", "AggregateObjective"]]
-    ) -> dict[str, Any]:
+    ) -> dict[str, float]:
         """Get the post-processed objective function outputs for this case.
 
         Args:
             objectives (list[&#39;Objective&#39;, &#39;AggregateObjective&#39;])
 
         Returns:
-            dict[str, Any]: Mapping of objective name to output value
+            dict[str, float]: Mapping of objective name to scalar output value
         """
-        output_mapping = {}
+        output_mapping: dict[str, float] = {}
 
         for obj in objectives:
             out = obj.data_for_case(self, post_processed=True)
             if out is None:
                 raise ValueError(f"Objective='{obj.name}' output None for case {self}")
 
-            output_mapping[obj.name] = out
+            output_mapping[obj.name] = coerce_objective_scalar(
+                out,
+                label=f"Post-processed objective '{obj.name}' output",
+            )
 
         return output_mapping
 

--- a/flowboost/optimizer/backend.py
+++ b/flowboost/optimizer/backend.py
@@ -7,6 +7,7 @@ from typing import Any, Union
 
 from flowboost.openfoam.case import Case
 from flowboost.optimizer.objectives import AggregateObjective, Objective
+from flowboost.optimizer.scalars import coerce_objective_scalar
 from flowboost.optimizer.search_space import Dimension
 
 DEFAULT_OFFLOAD_RESULT_FNAME = "acquisition_result.json"
@@ -243,25 +244,20 @@ class Backend(ABC):
             raw_objective_results = {}
             for obj_idx, objective in enumerate(self.objectives):
                 # Post-processed value
-                value = final_outputs[obj_idx][case_idx]
-                if hasattr(value, 'item'):
-                    value = value.item()
-                elif hasattr(value, 'tolist'):
-                    value = value.tolist()
-
+                value = coerce_objective_scalar(
+                    final_outputs[obj_idx][case_idx],
+                    label=f"Post-processed objective '{objective.name}' output",
+                )
                 objective_results[objective.name] = {
-                    "value": float(value),
+                    "value": value,
                     "minimize": objective.minimize,
                 }
 
                 # Raw value (before post-processing)
-                raw_value = raw_outputs[obj_idx][case_idx]
-                if hasattr(raw_value, 'item'):
-                    raw_value = raw_value.item()
-                elif hasattr(raw_value, 'tolist'):
-                    raw_value = raw_value.tolist()
-
-                raw_objective_results[objective.name] = float(raw_value)
+                raw_objective_results[objective.name] = coerce_objective_scalar(
+                    raw_outputs[obj_idx][case_idx],
+                    label=f"Raw objective '{objective.name}' output",
+                )
 
             # Save post-processed values
             case.update_metadata(objective_results, entry_header="objective-outputs")

--- a/flowboost/optimizer/interfaces/Ax.py
+++ b/flowboost/optimizer/interfaces/Ax.py
@@ -11,6 +11,7 @@ from ax.service.ax_client import AxClient, ObjectiveProperties, TParameterizatio
 from flowboost.openfoam.case import Case
 from flowboost.optimizer.backend import Backend
 from flowboost.optimizer.objectives import AggregateObjective, Objective
+from flowboost.optimizer.scalars import coerce_objective_scalar
 from flowboost.optimizer.search_space import Dimension
 
 
@@ -139,7 +140,13 @@ class AxBackend(Backend):
 
             # TODO support user's noise preference!
             raw_data = {
-                obj_name: (outcome, 0.0)
+                obj_name: (
+                    coerce_objective_scalar(
+                        outcome,
+                        label=f"Offloaded objective '{obj_name}' output",
+                    ),
+                    0.0,
+                )
                 for obj_name, outcome in data_dict["objectives"].items()
             }
 
@@ -464,7 +471,13 @@ class AxBackend(Backend):
 
             # Construct tuple-based result for case: see Ax TEvaluationOutcome
             raw_data = {
-                obj_name: (outcome, self._SEM_by_objective.get(obj_name, 0.0))
+                obj_name: (
+                    coerce_objective_scalar(
+                        outcome,
+                        label=f"Objective '{obj_name}' output for Ax",
+                    ),
+                    self._SEM_by_objective.get(obj_name, 0.0),
+                )
                 for obj_name, outcome in objective_f_outputs[case].items()
             }
 

--- a/flowboost/optimizer/interfaces/Ax.py
+++ b/flowboost/optimizer/interfaces/Ax.py
@@ -203,7 +203,7 @@ class AxBackend(Backend):
 
         with open(from_file, "r") as json_f:
             json_d = json.load(json_f)
-            ax.client.from_json_snapshot(json_d)
+            ax.client = AxClient.from_json_snapshot(json_d)
 
         logging.info("Restored Ax state from json snapshot")
         return ax

--- a/flowboost/optimizer/objectives.py
+++ b/flowboost/optimizer/objectives.py
@@ -6,6 +6,7 @@ import numpy as np
 from sklearn.preprocessing import MinMaxScaler, PowerTransformer
 
 from flowboost.openfoam.case import Case
+from flowboost.optimizer.scalars import coerce_objective_scalar
 
 
 class Objective:
@@ -91,10 +92,11 @@ class Objective:
         # post-processing function during evaluation.
         self._post_processing_steps: list[tuple[Callable, Any]] = []
 
-        # Data storage for each case that gets evaluated by this objective
-        # _objective_output_data is raw, pre-post-processed data.
+        # Data storage for each case that gets evaluated by this objective.
+        # Raw outputs may be arbitrary, but post-processed outputs must be
+        # scalar numerics suitable for optimization backends.
         self._objective_output_data: dict[Case, Any] = {}
-        self._post_processed_data: dict[Case, Any] = {}
+        self._post_processed_data: dict[Case, float] = {}
 
         if normalization_step:
             self.add_normalization_step(method=normalization_step)
@@ -150,7 +152,7 @@ class Objective:
 
     def execute_post_processing_steps(
         self, cases: list[Case], outputs: list[Any], save_output: bool = True
-    ) -> dict[Case, Any]:
+    ) -> dict[Case, float]:
         if len(outputs) != len(cases):
             raise ValueError(
                 f"Case count != output count: cases={cases}, outputs={outputs}"
@@ -170,9 +172,12 @@ class Objective:
 
         # Optionally, save post-processed outputs back to a dictionary keyed by Case
         # if specific per-case post-processed data is needed for further analysis
-        out_dict: dict[Case, Any] = {}
+        out_dict: dict[Case, float] = {}
         for case, processed_output in zip(cases, outputs):
-            out_dict[case] = processed_output
+            out_dict[case] = coerce_objective_scalar(
+                processed_output,
+                label=f"Post-processed objective '{self.name}' output",
+            )
 
         if save_output:
             self._post_processed_data = out_dict
@@ -288,10 +293,11 @@ class AggregateObjective:
 
         self._post_processing_steps: list[tuple[Callable, dict[str, Any]]] = []
 
-        # Data storage for each case that gets evaluated by this objective
-        # _objective_output_data is raw, pre-post-processed data.
+        # Data storage for each case that gets evaluated by this objective.
+        # Raw outputs may be tuples across objectives, but the final aggregated
+        # values stored for backends are scalar numerics.
         self._objective_output_data: dict[Case, Any] = {}
-        self._post_processed_data: dict[Case, Any] = {}
+        self._post_processed_data: dict[Case, float] = {}
 
         if len(self.weights) != len(self.objectives):
             raise ValueError("Length of weights must match number of objectives")
@@ -420,4 +426,5 @@ class ScikitNormalizationStep:
         self.normalizer = scikit_normalizer
 
     def evaluate(self, input: list) -> list:
-        return list(self.normalizer.fit_transform(np.array(input).reshape(-1, 1)))
+        normalized = self.normalizer.fit_transform(np.array(input).reshape(-1, 1))
+        return normalized.reshape(-1).tolist()

--- a/flowboost/optimizer/scalars.py
+++ b/flowboost/optimizer/scalars.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from flowboost.optimizer.search_space import Dimension
+
+
+def coerce_objective_scalar(value: Any, *, label: str = "Objective output") -> float:
+    """Coerce scalar-like objective data to a native Python float.
+
+    Accepts Python numeric scalars, NumPy numeric scalars, and size-1
+    ``ndarray`` / ``list`` / ``tuple`` containers. Multi-element containers are
+    rejected because collapsing them would change the optimization target.
+    """
+
+    unwrapped = _unwrap_scalar_like(value, label=label)
+
+    try:
+        return Dimension._coerce(unwrapped, "float")
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{label} must be numeric, got {value!r}") from exc
+
+
+def _unwrap_scalar_like(value: Any, *, label: str) -> Any:
+    if value is None:
+        raise ValueError(f"{label} must be scalar-like, got None")
+
+    if isinstance(value, np.ndarray):
+        if value.size != 1:
+            raise ValueError(
+                f"{label} must be scalar-like, got ndarray with {value.size} values"
+            )
+        return _unwrap_scalar_like(value.reshape(-1)[0], label=label)
+
+    if isinstance(value, (list, tuple)):
+        if len(value) != 1:
+            raise ValueError(
+                f"{label} must be scalar-like, got {type(value).__name__} with "
+                f"{len(value)} values"
+            )
+        return _unwrap_scalar_like(value[0], label=label)
+
+    if isinstance(value, np.generic):
+        return value.item()
+
+    return value

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,9 @@
 [project]
 name = "flowboost"
-version = "0.2.4"
+version = "0.2.5"
 description = "Multi-objective Bayesian optimization library for OpenFOAM"
 license = "Apache-2.0"
+license-files = ["LICENSE"]
 authors = [
     { name = "Daniel Virokannas", email = "46869890+499602D2@users.noreply.github.com" },
 ]
@@ -23,7 +24,6 @@ keywords = [
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: Apache Software License",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3",
     "Topic :: Scientific/Engineering",
@@ -41,10 +41,8 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-lts-cpu = ["polars-lts-cpu>=0.20"]
-viz = [
-    "pyvista>=0.47.1",
-]
+lts-cpu = ["polars-lts-cpu>=1.11"]
+viz = ["pyvista>=0.47.1"]
 
 [project.urls]
 Repository = "https://github.com/499602D2/flowboost"
@@ -60,7 +58,7 @@ dev = [
 ]
 
 [build-system]
-requires = ["uv_build>=0.10.4,<0.11.0"]
+requires = ["uv_build>=0.11.0,<0.12.0"]
 build-backend = "uv_build"
 
 [tool.uv.build-backend]

--- a/tests/flowboost/optimizer/test_backend.py
+++ b/tests/flowboost/optimizer/test_backend.py
@@ -135,3 +135,27 @@ def test_prepare_for_acquisition_offload_serializes_normalized_outputs(
 
     assert type(objective_value) is float
     assert objective_value == 0.0
+
+
+def test_offloaded_acquisition_round_trip(data_dir, tmp_path):
+    case = _make_copied_case(data_dir, tmp_path, "roundtrip-case")
+    backend, _ = _make_normalized_backend(case)
+    backend.offload_acquisition = True
+    backend.initialize()
+
+    model_snapshot, data_snapshot = backend.prepare_for_acquisition_offload(
+        [case], [], tmp_path
+    )
+    output_path = tmp_path / "acquisition_result.json"
+
+    AxBackend.offloaded_acquisition(
+        model_snapshot=model_snapshot,
+        data_snapshot=data_snapshot,
+        num_trials=1,
+        output_path=output_path,
+    )
+
+    result = json.loads(output_path.read_text())
+    assert result["optimizer"] == "AxBackend"
+    assert result["status_finished"] is False
+    assert len(result["parametrizations"]) == 1

--- a/tests/flowboost/optimizer/test_backend.py
+++ b/tests/flowboost/optimizer/test_backend.py
@@ -1,7 +1,9 @@
+import json
 import logging
 
 import pytest
 
+from flowboost.openfoam.case import Case
 from flowboost.openfoam.dictionary import DictionaryLink
 from flowboost.optimizer.interfaces.Ax import AxBackend
 from flowboost.optimizer.objectives import Objective
@@ -68,3 +70,68 @@ def test_tell(Ax_backend, test_case, foam_in_env):
 
     logging.info("Running tell()")
     Ax_backend.tell([test_case])
+
+
+def _make_copied_case(data_dir, tmp_path, name: str) -> Case:
+    case = Case.copy(data_dir, tmp_path / name)
+    case.update_metadata(
+        {"test_dim": {"value": 0.5}},
+        entry_header="optimizer-suggestion",
+    )
+    return case
+
+
+def _make_normalized_backend(case: Case) -> tuple[AxBackend, Objective]:
+    objective = Objective(
+        name="normalized_objective",
+        minimize=True,
+        objective_function=lambda _: 1.0,
+        normalization_step="min-max",
+    )
+    outputs = objective.batch_evaluate([case])
+    objective.batch_post_process([case], outputs)
+
+    backend = AxBackend()
+    backend.set_search_space(
+        [
+            Dimension.range(
+                name="test_dim",
+                link=DictionaryLink("constant/chemistryProperties").entry(
+                    "tabulation/tolerance"
+                ),
+                lower=0.0,
+                upper=1.0,
+            )
+        ]
+    )
+    backend.set_objectives([objective])
+    return backend, objective
+
+
+def test_tell_accepts_normalized_scalar_like_outputs(data_dir, tmp_path):
+    case = _make_copied_case(data_dir, tmp_path, "normalized-case")
+    backend, _ = _make_normalized_backend(case)
+
+    backend.tell([case])
+
+    trial_index = backend._trial_index_case_mapping[case]
+    trial = backend.client.experiment.trials[trial_index]
+    assert trial.status.is_completed
+
+
+def test_prepare_for_acquisition_offload_serializes_normalized_outputs(
+    data_dir, tmp_path
+):
+    case = _make_copied_case(data_dir, tmp_path, "offload-case")
+    backend, _ = _make_normalized_backend(case)
+    backend.offload_acquisition = True
+    backend.initialize()
+
+    _, data_snapshot = backend.prepare_for_acquisition_offload([case], [], tmp_path)
+    snapshot_data = json.loads(data_snapshot.read_text())
+    objective_value = snapshot_data["finished_cases"][case.name]["objectives"][
+        "normalized_objective"
+    ]
+
+    assert type(objective_value) is float
+    assert objective_value == 0.0

--- a/tests/flowboost/optimizer/test_backend.py
+++ b/tests/flowboost/optimizer/test_backend.py
@@ -72,8 +72,10 @@ def test_tell(Ax_backend, test_case, foam_in_env):
     Ax_backend.tell([test_case])
 
 
-def _make_copied_case(data_dir, tmp_path, name: str) -> Case:
-    case = Case.copy(data_dir, tmp_path / name)
+def _make_case(tmp_path, name: str) -> Case:
+    case_dir = tmp_path / name
+    case_dir.mkdir()
+    case = Case(case_dir)
     case.update_metadata(
         {"test_dim": {"value": 0.5}},
         entry_header="optimizer-suggestion",
@@ -108,8 +110,8 @@ def _make_normalized_backend(case: Case) -> tuple[AxBackend, Objective]:
     return backend, objective
 
 
-def test_tell_accepts_normalized_scalar_like_outputs(data_dir, tmp_path):
-    case = _make_copied_case(data_dir, tmp_path, "normalized-case")
+def test_tell_accepts_normalized_scalar_like_outputs(tmp_path):
+    case = _make_case(tmp_path, "normalized-case")
     backend, _ = _make_normalized_backend(case)
 
     backend.tell([case])
@@ -120,9 +122,9 @@ def test_tell_accepts_normalized_scalar_like_outputs(data_dir, tmp_path):
 
 
 def test_prepare_for_acquisition_offload_serializes_normalized_outputs(
-    data_dir, tmp_path
+    tmp_path
 ):
-    case = _make_copied_case(data_dir, tmp_path, "offload-case")
+    case = _make_case(tmp_path, "offload-case")
     backend, _ = _make_normalized_backend(case)
     backend.offload_acquisition = True
     backend.initialize()
@@ -137,8 +139,8 @@ def test_prepare_for_acquisition_offload_serializes_normalized_outputs(
     assert objective_value == 0.0
 
 
-def test_offloaded_acquisition_round_trip(data_dir, tmp_path):
-    case = _make_copied_case(data_dir, tmp_path, "roundtrip-case")
+def test_offloaded_acquisition_round_trip(tmp_path):
+    case = _make_case(tmp_path, "roundtrip-case")
     backend, _ = _make_normalized_backend(case)
     backend.offload_acquisition = True
     backend.initialize()

--- a/tests/flowboost/optimizer/test_objectives.py
+++ b/tests/flowboost/optimizer/test_objectives.py
@@ -59,3 +59,22 @@ def test_data_retrieval_post_processing(test_case):
     post_out = objective.data_for_case(test_case, post_processed=True)
 
     assert post_out == 1955 + 1, f"Post-proc out = {post_out} != 1955+1"
+
+
+def test_normalization_outputs_python_floats(test_case):
+    objective = Objective(
+        name="normalized_objective",
+        minimize=True,
+        objective_function=lambda _: 1.0,
+        normalization_step="min-max",
+    )
+
+    outputs = objective.batch_evaluate([test_case])
+    post_processed = objective.batch_post_process([test_case], outputs)
+    stored = objective.data_for_case(test_case, post_processed=True)
+    case_outputs = test_case.objective_function_outputs([objective])
+
+    assert post_processed == [0.0]
+    assert type(post_processed[0]) is float
+    assert type(stored) is float
+    assert case_outputs == {"normalized_objective": 0.0}

--- a/tests/flowboost/optimizer/test_scalars.py
+++ b/tests/flowboost/optimizer/test_scalars.py
@@ -1,0 +1,35 @@
+import numpy as np
+import pytest
+
+from flowboost.optimizer.scalars import coerce_objective_scalar
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (1, 1.0),
+        (np.float64(2.5), 2.5),
+        (np.array([3.5]), 3.5),
+        ([np.array([4.5])], 4.5),
+        (([5.5],), 5.5),
+    ],
+)
+def test_coerce_objective_scalar_accepts_scalar_like_values(value, expected):
+    result = coerce_objective_scalar(value)
+    assert result == pytest.approx(expected)
+    assert type(result) is float
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        None,
+        [],
+        [1.0, 2.0],
+        np.array([1.0, 2.0]),
+        "not-a-number",
+    ],
+)
+def test_coerce_objective_scalar_rejects_non_scalar_values(value):
+    with pytest.raises(ValueError, match="scalar-like|numeric"):
+        coerce_objective_scalar(value)

--- a/tests/flowboost/session/test_session_docker_integration.py
+++ b/tests/flowboost/session/test_session_docker_integration.py
@@ -1,0 +1,192 @@
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from flowboost import Case, Dictionary, Dimension, Manager, Objective, Session
+from flowboost.openfoam.runtime import FOAMRuntime, get_runtime, reset_runtime
+
+pytestmark = pytest.mark.slow
+
+
+@pytest.fixture(scope="module")
+def docker_foam_runtime(tmp_path_factory):
+    previous_mode = os.environ.get("FLOWBOOST_FOAM_MODE")
+    os.environ["FLOWBOOST_FOAM_MODE"] = "docker"
+    reset_runtime()
+
+    try:
+        runtime = get_runtime()
+    except RuntimeError:
+        _restore_foam_mode(previous_mode)
+        pytest.skip("Docker-based OpenFOAM runtime not available")
+
+    if runtime.mode != FOAMRuntime.Mode.DOCKER:
+        runtime.cleanup()
+        reset_runtime()
+        _restore_foam_mode(previous_mode)
+        pytest.skip("Docker-based OpenFOAM runtime not active")
+
+    if not runtime.is_available():
+        runtime.cleanup()
+        reset_runtime()
+        _restore_foam_mode(previous_mode)
+        pytest.skip("Docker-based OpenFOAM runtime not usable")
+
+    runtime.add_mount(tmp_path_factory.getbasetemp(), "/work")
+
+    try:
+        yield runtime
+    finally:
+        runtime.cleanup()
+        reset_runtime()
+        _restore_foam_mode(previous_mode)
+
+
+def _restore_foam_mode(previous_mode: str | None) -> None:
+    if previous_mode is None:
+        os.environ.pop("FLOWBOOST_FOAM_MODE", None)
+    else:
+        os.environ["FLOWBOOST_FOAM_MODE"] = previous_mode
+
+
+def _pressure_drop_objective(case: Case) -> float | None:
+    fo_name = "patchAverage(patch=inlet,fields=(pU))"
+    df = case.data.simple_function_object_reader(fo_name, backend="pandas")
+
+    if df is None or df.empty:
+        return None
+
+    return float(df["areaAverage(p)"].iloc[-1])
+
+
+def _configure_pitzdaily_case(case_dir: Path) -> Case:
+    case = Case.from_tutorial("incompressibleFluid/pitzDaily", case_dir)
+    case.foam_get("patchAverage")
+
+    patch_average = case.dictionary("system/patchAverage")
+    patch_average.set("patch", "inlet")
+    patch_average.set("fields", "(p U)")
+
+    control_dict = case.dictionary("system/controlDict")
+    control_dict.entry("endTime").set("0.01")
+
+    return case
+
+
+def _wait_for_finished_job(manager: Manager, timeout_seconds: int = 180):
+    deadline = time.monotonic() + timeout_seconds
+
+    while time.monotonic() < deadline:
+        finished_jobs = {
+            job for job in manager.job_pool if manager._job_has_finished(job.id)
+        }
+        if finished_jobs:
+            manager.job_pool.difference_update(finished_jobs)
+            manager._save_state()
+            return list(finished_jobs)
+
+        time.sleep(1)
+
+    tracked = ", ".join(sorted(job.name for job in manager.job_pool)) or "none"
+    raise TimeoutError(f"Timed out waiting for DockerLocal job(s): {tracked}")
+
+
+def _build_pitzdaily_session(tmp_path: Path, max_evaluations: int) -> Session:
+    session = Session(
+        name="pitzDaily-docker-test",
+        data_dir=tmp_path / "session_data",
+        max_evaluations=max_evaluations,
+    )
+
+    template = _configure_pitzdaily_case(session.data_dir / "pitzDaily_template")
+    session.attach_template_case(case=template)
+
+    objective = Objective(
+        name="inlet_pressure",
+        minimize=True,
+        objective_function=_pressure_drop_objective,
+        normalization_step="min-max",
+    )
+    session.backend.set_objectives([objective])
+
+    inlet_k = Dictionary.link("0/k").entry("boundaryField/inlet/value")
+    session.backend.set_search_space(
+        [
+            Dimension.range(
+                name="inlet_k",
+                link=inlet_k,
+                lower=0.1,
+                upper=1.5,
+                log_scale=True,
+            )
+        ]
+    )
+
+    session.job_manager = Manager.create(
+        scheduler="dockerlocal", wdir=session.data_dir, job_limit=1
+    )
+    session.job_manager.monitoring_interval = 1
+    session.backend.initialization_trials = 1
+    session.clean_pending_cases()
+    return session
+
+
+def test_pitzdaily_dockerlocal_example_smoke(docker_foam_runtime, tmp_path):
+    manager = Manager.create(scheduler="dockerlocal", wdir=tmp_path, job_limit=1)
+    case = _configure_pitzdaily_case(tmp_path / "pitzDaily_case")
+
+    assert manager.submit_case(case)
+
+    finished_jobs = _wait_for_finished_job(manager)
+    assert len(finished_jobs) == 1
+    assert _pressure_drop_objective(case) is not None
+
+    function_object_dir = (
+        case.path / "postProcessing" / "patchAverage(patch=inlet,fields=(pU))"
+    )
+    assert function_object_dir.exists()
+
+
+def test_session_loop_optimizer_cycle_with_dockerlocal(docker_foam_runtime, tmp_path):
+    session = _build_pitzdaily_session(tmp_path, max_evaluations=2)
+    manager = session.job_manager
+    assert manager is not None
+
+    session.backend.initialize()
+
+    first_cases = session.loop_optimizer_once(num_new_cases=1)
+    assert len(first_cases) == 1
+    first_case = first_cases[0]
+    assert manager.submit_case(first_case)
+
+    first_job = _wait_for_finished_job(manager)[0]
+    first_dest = session.archival_dir / first_job.wdir.name
+    assert manager.move_data_for_job(first_job, first_dest)
+    archived_first = Case(first_dest)
+    archived_first.post_evaluation_update(first_job.to_dict())
+
+    second_cases = session.loop_optimizer_once(num_new_cases=1)
+    assert len(second_cases) == 1
+
+    first_metadata = archived_first.read_metadata()
+    assert first_metadata is not None
+    assert type(float(first_metadata["objective-values-raw"]["inlet_pressure"])) is float
+    assert type(float(first_metadata["objective-outputs"]["inlet_pressure"]["value"])) is float
+
+    second_case = second_cases[0]
+    assert manager.submit_case(second_case)
+
+    second_job = _wait_for_finished_job(manager)[0]
+    second_dest = session.archival_dir / second_job.wdir.name
+    assert manager.move_data_for_job(second_job, second_dest)
+    Case(second_dest).post_evaluation_update(second_job.to_dict())
+
+    finished_cases = session.get_finished_cases(include_failed=False, batch_process=True)
+    assert len(finished_cases) == 2
+    for case in finished_cases:
+        outputs = case.objective_function_outputs(session.backend.objectives)
+        assert type(outputs["inlet_pressure"]) is float
+
+    assert session._check_termination_criteria()

--- a/uv.lock
+++ b/uv.lock
@@ -841,7 +841,7 @@ wheels = [
 
 [[package]]
 name = "flowboost"
-version = "0.2.4"
+version = "0.2.5"
 source = { editable = "." }
 dependencies = [
     { name = "ax-platform", version = "1.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -881,7 +881,7 @@ requires-dist = [
     { name = "coloredlogs", specifier = ">=15" },
     { name = "pandas", specifier = ">=2.2" },
     { name = "polars", specifier = ">=1.11" },
-    { name = "polars-lts-cpu", marker = "extra == 'lts-cpu'", specifier = ">=0.20" },
+    { name = "polars-lts-cpu", marker = "extra == 'lts-cpu'", specifier = ">=1.11" },
     { name = "psutil", specifier = ">=5.9" },
     { name = "pyarrow", specifier = ">=15" },
     { name = "pyvista", marker = "extra == 'viz'", specifier = ">=0.47.1" },
@@ -3163,6 +3163,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/8b/4b61d6e13f7108f36910df9ab4b58fd389cc2520d54d81b88660804aad99/torch-2.10.0-2-cp311-none-macosx_11_0_arm64.whl", hash = "sha256:418997cb02d0a0f1497cf6a09f63166f9f5df9f3e16c8a716ab76a72127c714f", size = 79423467, upload-time = "2026-02-10T21:44:48.711Z" },
     { url = "https://files.pythonhosted.org/packages/d3/54/a2ba279afcca44bbd320d4e73675b282fcee3d81400ea1b53934efca6462/torch-2.10.0-2-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:13ec4add8c3faaed8d13e0574f5cd4a323c11655546f91fbe6afa77b57423574", size = 79498202, upload-time = "2026-02-10T21:44:52.603Z" },
     { url = "https://files.pythonhosted.org/packages/ec/23/2c9fe0c9c27f7f6cb865abcea8a4568f29f00acaeadfc6a37f6801f84cb4/torch-2.10.0-2-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:e521c9f030a3774ed770a9c011751fb47c4d12029a3d6522116e48431f2ff89e", size = 79498254, upload-time = "2026-02-10T21:44:44.095Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ee/efbd56687be60ef9af0c9c0ebe106964c07400eade5b0af8902a1d8cd58c/torch-2.10.0-3-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:a1ff626b884f8c4e897c4c33782bdacdff842a165fee79817b1dd549fdda1321", size = 915510070, upload-time = "2026-03-11T14:16:39.386Z" },
+    { url = "https://files.pythonhosted.org/packages/36/ab/7b562f1808d3f65414cd80a4f7d4bb00979d9355616c034c171249e1a303/torch-2.10.0-3-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:ac5bdcbb074384c66fa160c15b1ead77839e3fe7ed117d667249afce0acabfac", size = 915518691, upload-time = "2026-03-11T14:15:43.147Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7a/abada41517ce0011775f0f4eacc79659bc9bc6c361e6bfe6f7052a6b9363/torch-2.10.0-3-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:98c01b8bb5e3240426dcde1446eed6f40c778091c8544767ef1168fc663a05a6", size = 915622781, upload-time = "2026-03-11T14:17:11.354Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/c6/4dfe238342ffdcec5aef1c96c457548762d33c40b45a1ab7033bb26d2ff2/torch-2.10.0-3-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:80b1b5bfe38eb0e9f5ff09f206dcac0a87aadd084230d4a36eea5ec5232c115b", size = 915627275, upload-time = "2026-03-11T14:16:11.325Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f0/72bf18847f58f877a6a8acf60614b14935e2f156d942483af1ffc081aea0/torch-2.10.0-3-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:46b3574d93a2a8134b3f5475cfb98e2eb46771794c57015f6ad1fb795ec25e49", size = 915523474, upload-time = "2026-03-11T14:17:44.422Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/39/590742415c3030551944edc2ddc273ea1fdfe8ffb2780992e824f1ebee98/torch-2.10.0-3-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:b1d5e2aba4eb7f8e87fbe04f86442887f9167a35f092afe4c237dfcaaef6e328", size = 915632474, upload-time = "2026-03-11T14:15:13.666Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/8e/34949484f764dde5b222b7fe3fede43e4a6f0da9d7f8c370bb617d629ee2/torch-2.10.0-3-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:0228d20b06701c05a8f978357f657817a4a63984b0c90745def81c18aedfa591", size = 915523882, upload-time = "2026-03-11T14:14:46.311Z" },
     { url = "https://files.pythonhosted.org/packages/0c/1a/c61f36cfd446170ec27b3a4984f072fd06dab6b5d7ce27e11adb35d6c838/torch-2.10.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:5276fa790a666ee8becaffff8acb711922252521b28fbce5db7db5cf9cb2026d", size = 145992962, upload-time = "2026-01-21T16:24:14.04Z" },
     { url = "https://files.pythonhosted.org/packages/b5/60/6662535354191e2d1555296045b63e4279e5a9dbad49acf55a5d38655a39/torch-2.10.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:aaf663927bcd490ae971469a624c322202a2a1e68936eb952535ca4cd3b90444", size = 915599237, upload-time = "2026-01-21T16:23:25.497Z" },
     { url = "https://files.pythonhosted.org/packages/40/b8/66bbe96f0d79be2b5c697b2e0b187ed792a15c6c4b8904613454651db848/torch-2.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:a4be6a2a190b32ff5c8002a0977a25ea60e64f7ba46b1be37093c141d9c49aeb", size = 113720931, upload-time = "2026-01-21T16:24:23.743Z" },


### PR DESCRIPTION
## Summary
- coerce optimizer-facing objective outputs to scalar floats
- fix Ax/offload handling for normalized outputs
- add regression coverage, including a real Docker/OpenFOAM pitzDaily session smoke

## Validation
- optimizer tests
- Docker-backed session integration tests
- build metadata check

Closes #16