### PR TITLE
Fix session crash, deduplicate parameter generation by default

### DIFF
--- a/flowboost/optimizer/interfaces/Ax.py
+++ b/flowboost/optimizer/interfaces/Ax.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional, Union
 
+from ax.core.arm import Arm
 from ax.core.base_trial import BaseTrial
 from ax.service.ax_client import AxClient, ObjectiveProperties, TParameterization
 
@@ -34,6 +35,8 @@ class AxBackend(Backend):
         self.SAASBO: bool = False
         self.max_parallelism: Optional[int] = None
         self.initialization_trials: Optional[int] = None
+        self.random_seed: Optional[int] = None
+        self.should_deduplicate: bool = True
 
         # Ax-specific constraints
         self._parameter_constraints: list[str] = []
@@ -72,6 +75,8 @@ class AxBackend(Backend):
                 "use_saasbo": self.SAASBO,
                 "disable_progbar": False,
                 "max_parallelism_override": self.max_parallelism,
+                "random_seed": self.random_seed,
+                "should_deduplicate": self.should_deduplicate,
             },
         )
 
@@ -134,8 +139,9 @@ class AxBackend(Backend):
         # Attach finished trials to backend
         logging.info("Attaching finished trials")
         for case_name, data_dict in data["finished_cases"].items():
-            _, idx = ax.client.attach_trial(
-                parameters=data_dict["parametrization"], arm_name=case_name
+            idx = ax._attach_trial_with_case_name(
+                parameters=data_dict["parametrization"],
+                case_name=case_name,
             )
 
             # TODO support user's noise preference!
@@ -155,8 +161,9 @@ class AxBackend(Backend):
         # Attach pending trials to backend
         logging.info("Attaching pending trials")
         for case_name, data_dict in data["pending_cases"].items():
-            _, idx = ax.client.attach_trial(
-                parameters=data_dict["parametrization"], arm_name=case_name
+            idx = ax._attach_trial_with_case_name(
+                parameters=data_dict["parametrization"],
+                case_name=case_name,
             )
 
         # Run acquisition
@@ -437,10 +444,42 @@ class AxBackend(Backend):
             p = case.parametrize_configuration(self.dimensions)
 
             logging.info(f"Attaching c={case.name}, p={p}")
-            _, idx = self.client.attach_trial(parameters=p, arm_name=case.name)
+            idx = self._attach_trial_with_case_name(parameters=p, case_name=case.name)
 
             # TODO if we were to run in stateful mode, we'd stash the index
             self._trial_index_case_mapping[case] = idx
+
+    def _attach_trial_with_case_name(
+        self, parameters: TParameterization, case_name: str
+    ) -> int:
+        """Attach a trial while preserving Ax's existing arm identity for duplicates."""
+        arm_name = self._arm_name_for_attachment(
+            parameters=parameters,
+            case_name=case_name,
+        )
+        _, trial_index = self.client.attach_trial(
+            parameters=parameters,
+            arm_name=arm_name,
+        )
+        return trial_index
+
+    def _arm_name_for_attachment(
+        self, parameters: TParameterization, case_name: str
+    ) -> str:
+        """Return the correct arm name for this parameterization in the experiment."""
+        existing_arm = self.client.experiment.arms_by_signature.get(
+            Arm.md5hash(parameters)
+        )
+        if existing_arm is None:
+            return case_name
+
+        if existing_arm.name != case_name:
+            logging.info(
+                "Reusing existing arm '%s' for duplicate parameters from case '%s'",
+                existing_arm.name,
+                case_name,
+            )
+        return existing_arm.name
 
     def _can_abandon_trial(self, trial: BaseTrial) -> bool:
         if trial is None:

--- a/flowboost/session/session.py
+++ b/flowboost/session/session.py
@@ -30,6 +30,7 @@ class Session:
         dataframe_format: str = "polars",
         backend: str = "AxBackend",
         clone_method: Literal["foamCloneCase", "copy"] = "foamCloneCase",
+        random_seed: Optional[int] = None,
         max_evaluations: Optional[int] = None,
         target_value: Optional[float] = None,
         target_objective: Optional[str] = None,
@@ -48,6 +49,8 @@ class Session:
                 basis. Defaults to polars.
             backend (str, optional): Optimization backend to use. Defaults to "Ax".
             clone_method (Literal["foamCloneCase", "copy"], optional): Method to use for cloning cases. Defaults to "foamCloneCase".
+            random_seed (Optional[int], optional): Optional optimizer seed for \
+                reproducible candidate generation. Defaults to None.
             max_evaluations (Optional[int], optional): Maximum number of evaluations \
                 before stopping optimization. Defaults to None (no limit).
             target_value (Optional[float], optional): Target objective value to reach. \
@@ -62,6 +65,7 @@ class Session:
         self.created_at: datetime = datetime.now(tz=timezone.utc)
         self.dataframe_format: str = dataframe_format
         self.clone_method: Literal["foamCloneCase", "copy"] = clone_method
+        self.random_seed: Optional[int] = random_seed
 
         # Termination criteria
         self.max_evaluations: Optional[int] = max_evaluations
@@ -78,6 +82,7 @@ class Session:
 
         # Optimizer
         self.backend: Backend = Backend.create(backend)
+        self._apply_backend_preferences()
         self.job_manager: Optional[Manager] = None
 
         # Template simulation that optimization points are derived from
@@ -435,6 +440,13 @@ class Session:
         """
         Return the session state as a dictionary.
         """
+        optimizer_state = {
+            "type": self.backend.type,
+            "offload_acquisition": self.backend.offload_acquisition,
+        }
+        if self.random_seed is not None:
+            optimizer_state["random_seed"] = self.random_seed
+
         state = {
             "session": {
                 "name": self.name,
@@ -448,10 +460,7 @@ class Session:
                 "path": str(self._template_case.path) if self._template_case else "",
                 "additional_files": self._template_case_add_files,
             },
-            "optimizer": {
-                "type": self.backend.type,
-                "offload_acquisition": self.backend.offload_acquisition,
-            },
+            "optimizer": optimizer_state,
             "scheduler": {
                 "type": self.job_manager.type if self.job_manager else "",
                 "job_limit": self.job_manager.job_limit if self.job_manager else 1,
@@ -490,7 +499,9 @@ class Session:
 
         # [optimizer]
         backend_type = str(data.get("optimizer", {}).get("type", "Ax"))
-        self.backend.create(backend_type)
+        self.random_seed = data.get("optimizer", {}).get("random_seed")
+        self.backend = Backend.create(backend_type)
+        self._apply_backend_preferences()
         offload = data.get("optimizer", {}).get("offload_acquisition", False)
         if offload:
             self.backend.offload_acquisition = offload
@@ -506,6 +517,11 @@ class Session:
 
         logging.info(f"Session restored from {from_file}")
         # No automatic pending case cleanup here.
+
+    def _apply_backend_preferences(self):
+        """Apply session-level optimizer settings to the active backend when supported."""
+        if hasattr(self.backend, "random_seed"):
+            self.backend.random_seed = self.random_seed
 
     def clean_pending_cases(self):
         """

--- a/tests/flowboost/optimizer/test_backend.py
+++ b/tests/flowboost/optimizer/test_backend.py
@@ -72,15 +72,31 @@ def test_tell(Ax_backend, test_case, foam_in_env):
     Ax_backend.tell([test_case])
 
 
-def _make_case(tmp_path, name: str) -> Case:
+def _make_case(tmp_path, name: str, value: float = 0.5) -> Case:
+    return _make_case_with_params(tmp_path, name, {"test_dim": value})
+
+
+def _make_case_with_params(
+    tmp_path, name: str, params: dict[str, int | float | bool | str]
+) -> Case:
     case_dir = tmp_path / name
     case_dir.mkdir()
     case = Case(case_dir)
     case.update_metadata(
-        {"test_dim": {"value": 0.5}},
+        {key: {"value": value} for key, value in params.items()},
         entry_header="optimizer-suggestion",
     )
     return case
+
+
+def _evaluate_objective(case: Case, objective: Objective) -> None:
+    outputs = objective.batch_evaluate([case])
+    objective.batch_post_process([case], outputs)
+
+
+def _evaluate_objective_batch(cases: list[Case], objective: Objective) -> None:
+    outputs = objective.batch_evaluate(cases)
+    objective.batch_post_process(cases, outputs)
 
 
 def _make_normalized_backend(case: Case) -> tuple[AxBackend, Objective]:
@@ -90,8 +106,7 @@ def _make_normalized_backend(case: Case) -> tuple[AxBackend, Objective]:
         objective_function=lambda _: 1.0,
         normalization_step="min-max",
     )
-    outputs = objective.batch_evaluate([case])
-    objective.batch_post_process([case], outputs)
+    _evaluate_objective(case, objective)
 
     backend = AxBackend()
     backend.set_search_space(
@@ -110,6 +125,66 @@ def _make_normalized_backend(case: Case) -> tuple[AxBackend, Objective]:
     return backend, objective
 
 
+def _make_issue_style_backend(
+    *, random_seed: int | None = None, should_deduplicate: bool = True
+) -> tuple[AxBackend, Objective]:
+    backend = AxBackend()
+    backend.initialization_trials = 1
+    backend.random_seed = random_seed
+    backend.should_deduplicate = should_deduplicate
+    backend.set_search_space(
+        [
+            Dimension.range(
+                name="heatSource",
+                link=DictionaryLink("constant/energy").entry("heatSource"),
+                lower=500.0,
+                upper=2000.0,
+            ),
+            Dimension.choice(
+                name="position",
+                link=DictionaryLink("constant/setup").entry("position"),
+                choices=[1, 3, 5, 7],
+                dtype=int,
+                is_ordered=True,
+            ),
+        ]
+    )
+    objective = Objective(
+        name="score",
+        minimize=True,
+        objective_function=lambda case: float(
+            case.read_metadata()["optimizer-suggestion"]["heatSource"]["value"]
+        )
+        + float(case.read_metadata()["optimizer-suggestion"]["position"]["value"]),
+    )
+    backend.set_objectives([objective])
+    return backend, objective
+
+
+def _collect_issue_style_suggestions(
+    tmp_path, backend: AxBackend, objective: Objective, limit: int
+) -> tuple[list[dict[str, int | float]], int | None, dict[str, int | float] | None]:
+    backend.initialize()
+
+    finished_cases: list[Case] = []
+    seen: list[dict[str, int | float]] = []
+
+    for i in range(1, limit + 1):
+        suggestion = backend.ask(1)[0]
+        params = {dim.name: value for dim, value in suggestion.items()}
+
+        if params in seen:
+            return seen, i, params
+
+        case = _make_case_with_params(tmp_path, f"issue-case-{i:02d}", params)
+        finished_cases.append(case)
+        _evaluate_objective_batch(finished_cases, objective)
+        seen.append(params)
+        backend.tell(finished_cases)
+
+    return seen, None, None
+
+
 def test_tell_accepts_normalized_scalar_like_outputs(tmp_path):
     case = _make_case(tmp_path, "normalized-case")
     backend, _ = _make_normalized_backend(case)
@@ -119,6 +194,32 @@ def test_tell_accepts_normalized_scalar_like_outputs(tmp_path):
     trial_index = backend._trial_index_case_mapping[case]
     trial = backend.client.experiment.trials[trial_index]
     assert trial.status.is_completed
+
+
+def test_tell_reuses_existing_arm_for_duplicate_parameterizations(tmp_path):
+    first_case = _make_case(tmp_path, "duplicate-a", value=0.5)
+    second_case = _make_case(tmp_path, "duplicate-b", value=0.5)
+    backend, objective = _make_normalized_backend(first_case)
+    _evaluate_objective_batch([first_case, second_case], objective)
+
+    backend.tell([first_case, second_case])
+
+    first_trial = backend.client.experiment.trials[
+        backend._trial_index_case_mapping[first_case]
+    ]
+    second_trial = backend.client.experiment.trials[
+        backend._trial_index_case_mapping[second_case]
+    ]
+
+    assert first_trial.index != second_trial.index
+    assert first_trial.status.is_completed
+    assert second_trial.status.is_completed
+    assert first_trial.arm is not None
+    assert second_trial.arm is not None
+    assert first_trial.arm.parameters == {"test_dim": 0.5}
+    assert second_trial.arm.parameters == {"test_dim": 0.5}
+    assert first_trial.arm.name == second_trial.arm.name == first_case.name
+    assert list(backend.client.experiment.arms_by_name) == [first_case.name]
 
 
 def test_prepare_for_acquisition_offload_serializes_normalized_outputs(
@@ -161,3 +262,94 @@ def test_offloaded_acquisition_round_trip(tmp_path):
     assert result["optimizer"] == "AxBackend"
     assert result["status_finished"] is False
     assert len(result["parametrizations"]) == 1
+
+
+def test_offloaded_acquisition_accepts_duplicate_parameterizations(tmp_path):
+    first_case = _make_case(tmp_path, "roundtrip-duplicate-a", value=0.5)
+    second_case = _make_case(tmp_path, "roundtrip-duplicate-b", value=0.5)
+    backend, objective = _make_normalized_backend(first_case)
+    _evaluate_objective_batch([first_case, second_case], objective)
+    backend.offload_acquisition = True
+    backend.initialize()
+
+    model_snapshot, data_snapshot = backend.prepare_for_acquisition_offload(
+        [first_case, second_case], [], tmp_path
+    )
+    output_path = tmp_path / "duplicate_acquisition_result.json"
+
+    AxBackend.offloaded_acquisition(
+        model_snapshot=model_snapshot,
+        data_snapshot=data_snapshot,
+        num_trials=1,
+        output_path=output_path,
+    )
+
+    result = json.loads(output_path.read_text())
+    assert result["optimizer"] == "AxBackend"
+    assert result["status_finished"] is False
+    assert len(result["parametrizations"]) == 1
+
+
+def test_issue_style_search_space_encoding_matches_ax_schema():
+    backend, _ = _make_issue_style_backend()
+
+    assert backend._get_ax_search_space() == [
+        {
+            "name": "heatSource",
+            "type": "range",
+            "value_type": "float",
+            "bounds": [500.0, 2000.0],
+            "log_scale": False,
+            "digits": None,
+        },
+        {
+            "name": "position",
+            "type": "choice",
+            "value_type": "int",
+            "values": [1, 3, 5, 7],
+            "is_ordered": True,
+        },
+    ]
+
+
+def test_issue_style_generation_can_repeat_without_deduplication(tmp_path):
+    backend, objective = _make_issue_style_backend(
+        random_seed=0,
+        should_deduplicate=False,
+    )
+
+    suggestions, duplicate_at, duplicate = _collect_issue_style_suggestions(
+        tmp_path,
+        backend,
+        objective,
+        limit=10,
+    )
+
+    assert duplicate_at is not None
+    assert duplicate_at <= 10
+    assert duplicate is not None
+    assert duplicate in suggestions
+
+
+def test_issue_style_generation_avoids_repeats_with_deduplication(tmp_path):
+    backend, objective = _make_issue_style_backend(
+        random_seed=0,
+        should_deduplicate=True,
+    )
+
+    suggestions, duplicate_at, duplicate = _collect_issue_style_suggestions(
+        tmp_path,
+        backend,
+        objective,
+        limit=10,
+    )
+
+    assert len(suggestions) == 10
+    assert duplicate_at is None
+    assert duplicate is None
+
+
+def test_ax_backend_deduplicates_by_default():
+    backend = AxBackend()
+
+    assert backend.should_deduplicate is True

--- a/tests/flowboost/session/test_session.py
+++ b/tests/flowboost/session/test_session.py
@@ -34,6 +34,38 @@ def test_restore(test_session: Session):
     print("Restored session")
 
 
+def test_session_random_seed_is_applied_to_backend(tmp_path):
+    session = Session(
+        name="Seeded session",
+        data_dir=tmp_path / "seeded_session",
+        random_seed=123,
+    )
+
+    assert session.random_seed == 123
+    assert hasattr(session.backend, "random_seed")
+    assert session.backend.random_seed == 123
+
+
+def test_session_restore_reapplies_random_seed_to_backend(tmp_path):
+    data_dir = tmp_path / "restored_seed_session"
+    created = Session(
+        name="Restored seed session",
+        data_dir=data_dir,
+        random_seed=321,
+    )
+    created.persist()
+
+    restored = Session(
+        name="ignored",
+        data_dir=data_dir,
+        random_seed=None,
+    )
+
+    assert restored.random_seed == 321
+    assert hasattr(restored.backend, "random_seed")
+    assert restored.backend.random_seed == 321
+
+
 def test_incorrect_startup():
     # Objective missing linked entry
     # Test missing dictionary

--- a/tests/flowboost/session/test_session_docker_integration.py
+++ b/tests/flowboost/session/test_session_docker_integration.py
@@ -133,6 +133,22 @@ def _build_pitzdaily_session(tmp_path: Path, max_evaluations: int) -> Session:
     return session
 
 
+def _submit_and_archive_case(session: Session, case: Case) -> Case:
+    manager = session.job_manager
+    assert manager is not None
+
+    assert manager.submit_case(case)
+
+    finished_job = _wait_for_finished_job(manager)[0]
+    archived_path = session.archival_dir / finished_job.wdir.name
+
+    assert manager.move_data_for_job(finished_job, archived_path)
+
+    archived_case = Case(archived_path)
+    archived_case.post_evaluation_update(finished_job.to_dict())
+    return archived_case
+
+
 def test_pitzdaily_dockerlocal_example_smoke(docker_foam_runtime, tmp_path):
     manager = Manager.create(scheduler="dockerlocal", wdir=tmp_path, job_limit=1)
     case = _configure_pitzdaily_case(tmp_path / "pitzDaily_case")
@@ -190,3 +206,56 @@ def test_session_loop_optimizer_cycle_with_dockerlocal(docker_foam_runtime, tmp_
         assert type(outputs["inlet_pressure"]) is float
 
     assert session._check_termination_criteria()
+
+
+def test_session_tell_allows_duplicate_parameterizations_with_dockerlocal(
+    docker_foam_runtime, tmp_path
+):
+    session = _build_pitzdaily_session(tmp_path, max_evaluations=3)
+    session.backend.initialize()
+
+    inlet_k = session.backend.dimensions[0]
+    duplicate_suggestion = {inlet_k: 0.5}
+
+    first_case = session._process_optimizer_suggestion([duplicate_suggestion])[0]
+    second_case = session._process_optimizer_suggestion([duplicate_suggestion])[0]
+
+    archived_first = _submit_and_archive_case(session, first_case)
+    archived_second = _submit_and_archive_case(session, second_case)
+
+    assert archived_first.name != archived_second.name
+    assert archived_first.parametrize_configuration(session.backend.dimensions) == {
+        "inlet_k": 0.5
+    }
+    assert archived_second.parametrize_configuration(session.backend.dimensions) == {
+        "inlet_k": 0.5
+    }
+
+    finished_cases = sorted(
+        session.get_finished_cases(include_failed=False, batch_process=True),
+        key=lambda case: case.name,
+    )
+    assert len(finished_cases) == 2
+
+    session.backend.tell(finished_cases)
+
+    attached_trials = {
+        case.name: session.backend.client.experiment.trials[
+            session.backend._trial_index_case_mapping[case]
+        ]
+        for case in finished_cases
+    }
+
+    assert set(attached_trials) == {archived_first.name, archived_second.name}
+    assert len({trial.index for trial in attached_trials.values()}) == 2
+    assert all(trial.status.is_completed for trial in attached_trials.values())
+    assert all(trial.arm is not None for trial in attached_trials.values())
+    assert {trial.arm.parameters["inlet_k"] for trial in attached_trials.values()} == {
+        0.5
+    }
+    assert {trial.arm.name for trial in attached_trials.values()} == {
+        finished_cases[0].name
+    }
+    assert list(session.backend.client.experiment.arms_by_name) == [
+        finished_cases[0].name
+    ]


### PR DESCRIPTION
* Fixes session crash due to Ax arm naming
* Deduplicate generated parameters natively in Ax client by default
* Add an optional argument to `Session` to add a seed for randomness (generation strategy only)

Will close #18