### PR TITLE
Fix/issue 18 boundary float noise

### DIFF
--- a/flowboost/openfoam/case.py
+++ b/flowboost/openfoam/case.py
@@ -438,7 +438,12 @@ class Case:
         for obj in objectives:
             out = obj.data_for_case(self, post_processed=True)
             if out is None:
-                raise ValueError(f"Objective='{obj.name}' output None for case {self}")
+                raise ValueError(
+                    f"Objective '{obj.name}' has no post-processed output for "
+                    f"case {self}. The case has not been evaluated yet — run "
+                    f"Backend.batch_process([case]) first, or fetch finished "
+                    f"cases via Session.get_finished_cases(batch_process=True)."
+                )
 
             output_mapping[obj.name] = coerce_objective_scalar(
                 out,

--- a/flowboost/optimizer/backend.py
+++ b/flowboost/optimizer/backend.py
@@ -19,6 +19,15 @@ class Backend(ABC):
         self.objectives: list[Union[Objective, AggregateObjective]] = []
         self.dimensions: list[Dimension] = []
         self.offload_acquisition: bool = False
+        self._initialized: bool = False
+
+    def _ensure_initialized(self, op: str) -> None:
+        if not self._initialized:
+            raise RuntimeError(
+                f"Backend.{op}() called before initialize(). Call "
+                f"backend.initialize() (or Session.start()) after setting "
+                f"objectives and the search space."
+            )
 
     @staticmethod
     def create(backend: str) -> "Backend":
@@ -73,6 +82,7 @@ class Backend(ABC):
         pass
 
     def ask(self, max_cases: int) -> list[dict[Dimension, Any]]:
+        self._ensure_initialized("ask")
         parametrizations = self._ask(max_cases)
         return self._post_process_suggestion_parametrizations(parametrizations)
 
@@ -313,3 +323,10 @@ class Backend(ABC):
 
         if not self._dim_names_are_unique():
             raise ValueError("All Dimension names must be unique")
+
+
+class OptimizationComplete(Exception):
+    """Raised by a backend when the optimizer has exhausted its budget and
+    no further trials can be produced. Callers (typically ``Session``) are
+    expected to catch this and shut down the loop cleanly.
+    """

--- a/flowboost/optimizer/interfaces/Ax.py
+++ b/flowboost/optimizer/interfaces/Ax.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional, Union
@@ -10,7 +9,7 @@ from ax.core.base_trial import BaseTrial
 from ax.service.ax_client import AxClient, ObjectiveProperties, TParameterization
 
 from flowboost.openfoam.case import Case
-from flowboost.optimizer.backend import Backend
+from flowboost.optimizer.backend import Backend, OptimizationComplete
 from flowboost.optimizer.objectives import AggregateObjective, Objective
 from flowboost.optimizer.scalars import coerce_objective_scalar
 from flowboost.optimizer.search_space import Dimension
@@ -81,6 +80,7 @@ class AxBackend(Backend):
         )
 
         logging.info("Ax experiment initialized")
+        self._initialized = True
 
     def produce_state_snapshot(self, save_in: Path) -> Path:
         """
@@ -320,18 +320,18 @@ class AxBackend(Backend):
         )
 
         if finished:
-            logging.info("🎉 Optimization finished")
-            sys.exit("Optimization finished: can not proceed further")
+            logging.info("Optimization finished")
+            raise OptimizationComplete(
+                "Ax reports the optimization is finished; no further trials "
+                "can be generated."
+            )
 
         logging.info(f"Received {len(new_parametrizations)} new trial(s) from Ax")
 
-        # TODO handle case where 0 trials returned and we don't want to ask for
-        # new trials. Can be at the end of Sobol seeding phase.
-        if len(new_parametrizations) == 0:
-            raise ValueError("Cannot proceed: no trials received (TODO fix)")
-
-        # Convert the parametrizations back to be mapped by Dimensions
-        # TODO: this discards the trial ID!
+        # Empty is a legitimate mid-run state — e.g. the current generation
+        # node is at its parallelism cap and needs more completions before it
+        # can advance. Return empty and let the caller decide (Session will
+        # skip this cycle).
         return new_parametrizations
 
     def tell(self, cases: list[Case]):

--- a/flowboost/optimizer/search_space.py
+++ b/flowboost/optimizer/search_space.py
@@ -1,7 +1,14 @@
 import logging
+import math
 from typing import Any, Literal, Optional, Type, Union
 
 from flowboost.openfoam.dictionary import DictionaryLink
+
+# Target significant-digit headroom when auto-picking `digits` for a float
+# range. Float64 carries ~15-17 significant digits, so 12 leaves room below
+# the last-bit noise that appears when BO converges on a box-constraint
+# boundary and would otherwise defeat Ax's hash-based arm deduplication.
+_DEFAULT_FLOAT_SIG_DIGITS = 12
 
 
 class Dimension:
@@ -49,11 +56,26 @@ class Dimension:
         dtype: Type = float,
         digits: Optional[int] = None,
     ) -> "Dimension":
+        """Create a range dimension.
+
+        When ``dtype is float`` and ``digits`` is not supplied, a
+        magnitude-aware default is picked so rounded values preserve ~12
+        significant digits while stripping the last-bit float noise that
+        appears when BO converges on a box-constraint boundary (see
+        ``_default_digits_for_bounds``). Pass ``digits`` explicitly to
+        override, or ``digits=-1`` to disable rounding entirely.
+        """
         dim = cls(name, "range")
         dim.linked_entry = link
         dim.bounds = [lower, upper]
         dim.log_scale = log_scale
         dim.value_type = Dimension._get_value_type_str(dtype)
+
+        if digits is None and dtype is float:
+            digits = _default_digits_for_bounds(lower, upper)
+        elif digits is not None and digits < 0:
+            digits = None
+
         dim.digits = digits
         return dim
 
@@ -151,11 +173,21 @@ class Dimension:
     def coerce_value(self, value: Any) -> Any:
         """Coerce *value* to this dimension's declared ``value_type``.
 
+        For float-typed dimensions with ``digits`` set, the result is also
+        rounded to that many decimal places. This mirrors what Ax's
+        ``RangeParameter`` does on generated values and, crucially, also
+        applies to values coming back from OpenFOAM dictionaries or being
+        re-attached via ``attach_trial`` — which Ax does *not* round. Without
+        this, BO-near-boundary float noise slips past ``Arm.md5hash`` dedup.
+
         Returns *value* unchanged when ``value_type`` is ``None``.
         """
         if self.value_type is None:
             return value
-        return Dimension._coerce(value, self.value_type)
+        coerced = Dimension._coerce(value, self.value_type)
+        if self.value_type == "float" and self.digits is not None:
+            coerced = round(coerced, self.digits)
+        return coerced
 
     @staticmethod
     def _coerce(value: Any, value_type: str) -> Any:
@@ -196,3 +228,21 @@ class Dimension:
             return Dimension._ensure_types_match(value, bool)
 
         return target(value)
+
+
+def _default_digits_for_bounds(
+    lower: Union[int, float], upper: Union[int, float]
+) -> int:
+    """Pick a decimal-place count that gives ``_DEFAULT_FLOAT_SIG_DIGITS``
+    significant digits across *lower* and *upper*.
+
+    Ax's ``digits`` is a count of decimal places, so a fixed default cuts
+    both ways — fine for ``[500, 2000]``, catastrophic for ``[1e-9, 1e-7]``.
+    This scales with the bounds' magnitude so small-valued dimensions keep
+    their precision.
+    """
+    max_magnitude = max(abs(float(lower)), abs(float(upper)))
+    if max_magnitude == 0:
+        return _DEFAULT_FLOAT_SIG_DIGITS
+    order = math.floor(math.log10(max_magnitude))
+    return max(0, _DEFAULT_FLOAT_SIG_DIGITS - (order + 1))

--- a/flowboost/session/session.py
+++ b/flowboost/session/session.py
@@ -13,7 +13,7 @@ from flowboost.openfoam.case import Case, path_is_foam_dir, unique_id
 from flowboost.openfoam.dictionary import Dictionary, DictionaryLink, DictionaryReader
 from flowboost.openfoam.types import FOAMType
 from flowboost.optimizer.acquisition_offload import OFFLOAD_SCRIPT
-from flowboost.optimizer.backend import DEFAULT_OFFLOAD_RESULT_FNAME
+from flowboost.optimizer.backend import DEFAULT_OFFLOAD_RESULT_FNAME, OptimizationComplete
 from flowboost.optimizer.interfaces.Ax import Backend
 from flowboost.optimizer.search_space import Dimension
 
@@ -217,7 +217,13 @@ class Session:
             self.print_top_designs(n=5)
 
             if was_acq_job:
-                self.handle_finished_acquisition_job(finished[0])
+                try:
+                    self.handle_finished_acquisition_job(finished[0])
+                except OptimizationComplete as exc:
+                    logging.info(f"Backend reports optimization complete: {exc}")
+                    self._write_designs_log()
+                    logging.info("Optimization complete!")
+                    return
                 continue
 
             for job in finished:
@@ -242,7 +248,13 @@ class Session:
                 return
 
             logging.info("Entering optimizer loop")
-            new_cases = self.loop_optimizer_once(num_new_cases=free_slots)
+            try:
+                new_cases = self.loop_optimizer_once(num_new_cases=free_slots)
+            except OptimizationComplete as exc:
+                logging.info(f"Backend reports optimization complete: {exc}")
+                self._write_designs_log()
+                logging.info("Optimization complete!")
+                return
 
             for case in new_cases:
                 self.job_manager.submit_case(
@@ -374,8 +386,10 @@ class Session:
 
         # THIS IS WHERE OPTIMIZATION COMPLETION IS CHECKED
         if data.get("status_finished", False) is True:
-            logging.info("Backends reported optimization as finished: exiting")
-            sys.exit("Optimization finished")
+            logging.info("Backend reported optimization as finished via offload result")
+            raise OptimizationComplete(
+                "Offloaded acquisition result reports optimization finished."
+            )
 
         logging.info(
             f"Loading acquisition result, created at: {data.get('created_at', 'unknown')}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flowboost"
-version = "0.2.6"
+version = "0.2.7"
 description = "Multi-objective Bayesian optimization library for OpenFOAM"
 license = "Apache-2.0"
 license-files = ["LICENSE"]

--- a/tests/flowboost/optimizer/test_backend.py
+++ b/tests/flowboost/optimizer/test_backend.py
@@ -5,6 +5,7 @@ import pytest
 
 from flowboost.openfoam.case import Case
 from flowboost.openfoam.dictionary import DictionaryLink
+from flowboost.optimizer.backend import OptimizationComplete
 from flowboost.optimizer.interfaces.Ax import AxBackend
 from flowboost.optimizer.objectives import Objective
 from flowboost.optimizer.search_space import Dimension
@@ -54,6 +55,57 @@ def Ax_backend() -> AxBackend:
 
 def test_initialization(Ax_backend):
     Ax_backend.initialize()
+
+
+def test_ask_before_initialize_raises_clear_error(Ax_backend):
+    """Calling ask() on a fresh backend used to surface a deep Ax
+    AssertionError; it should now raise a FlowBoost-level guidance message."""
+    with pytest.raises(RuntimeError, match="called before initialize"):
+        Ax_backend.ask(max_cases=1)
+
+
+def test_ask_raises_optimization_complete_instead_of_sys_exit(Ax_backend, monkeypatch):
+    """The backend used to call sys.exit when Ax reported the optimization
+    finished, which would kill the host process. It should now raise a
+    dedicated exception the caller can catch."""
+    Ax_backend.initialize()
+
+    def fake_get_next_trials(*args, **kwargs):
+        return ({}, True)  # empty parametrizations, finished=True
+
+    monkeypatch.setattr(
+        Ax_backend.client, "get_next_trials", fake_get_next_trials
+    )
+
+    with pytest.raises(OptimizationComplete):
+        Ax_backend.ask(max_cases=1)
+
+
+def test_ask_returns_empty_when_backend_yields_no_trials(Ax_backend, monkeypatch):
+    """An empty generator response (e.g. parallelism cap reached mid-run) is
+    a legitimate state; ask() should return an empty list, not raise."""
+    Ax_backend.initialize()
+
+    def fake_get_next_trials(*args, **kwargs):
+        return ({}, False)  # empty, not finished
+
+    monkeypatch.setattr(
+        Ax_backend.client, "get_next_trials", fake_get_next_trials
+    )
+
+    assert Ax_backend.ask(max_cases=1) == []
+
+
+def test_tell_on_unevaluated_case_raises_clear_error(tmp_path):
+    """Calling tell() with a case that hasn't been batch-processed used to
+    blow up with 'output None for case ...' from deep inside Case; it should
+    now point the caller at batch_process / get_finished_cases(batch_process=True)."""
+    unevaluated = _make_case(tmp_path, "unevaluated", value=0.5)
+    backend, _ = _make_normalized_backend(unevaluated)
+    other = _make_case(tmp_path, "other", value=0.25)
+
+    with pytest.raises(ValueError, match="has not been evaluated"):
+        backend.tell([other])
 
 
 def test_tell(Ax_backend, test_case, foam_in_env):

--- a/tests/flowboost/optimizer/test_backend.py
+++ b/tests/flowboost/optimizer/test_backend.py
@@ -222,6 +222,40 @@ def test_tell_reuses_existing_arm_for_duplicate_parameterizations(tmp_path):
     assert list(backend.client.experiment.arms_by_name) == [first_case.name]
 
 
+def test_tell_collapses_boundary_float_noise_onto_one_arm(tmp_path):
+    """Regression for #18: BO converging on a box boundary can emit
+    numerically-indistinguishable floats (e.g. ``500.0`` and
+    ``500.0000000000001``). Without range-level rounding, each hashes to a
+    distinct ``Arm.signature``, slipping past Ax's dedup and our
+    ``_arm_name_for_attachment`` lookup, and surfacing as "duplicate" top
+    designs. With the default ``digits`` applied to the dimension, the
+    values collapse onto the same arm before ever reaching Ax."""
+    exact = _make_case(tmp_path, "boundary-exact", value=0.5)
+    noisy_up = _make_case(tmp_path, "boundary-noisy-up", value=0.5 + 1e-14)
+    noisy_down = _make_case(tmp_path, "boundary-noisy-down", value=0.5 - 1e-14)
+
+    backend, objective = _make_normalized_backend(exact)
+    _evaluate_objective_batch([exact, noisy_up, noisy_down], objective)
+
+    # Sanity-check the precondition: default digits is set for a float range.
+    (dim,) = backend.dimensions
+    assert dim.digits is not None and dim.digits >= 11
+
+    backend.tell([exact, noisy_up, noisy_down])
+
+    for case in (exact, noisy_up, noisy_down):
+        assert case in backend._trial_index_case_mapping
+
+    arm_names = {
+        backend.client.experiment.trials[
+            backend._trial_index_case_mapping[c]
+        ].arm.name
+        for c in (exact, noisy_up, noisy_down)
+    }
+    assert arm_names == {exact.name}
+    assert list(backend.client.experiment.arms_by_name) == [exact.name]
+
+
 def test_prepare_for_acquisition_offload_serializes_normalized_outputs(
     tmp_path
 ):
@@ -300,7 +334,7 @@ def test_issue_style_search_space_encoding_matches_ax_schema():
             "value_type": "float",
             "bounds": [500.0, 2000.0],
             "log_scale": False,
-            "digits": None,
+            "digits": 8,
         },
         {
             "name": "position",

--- a/tests/flowboost/optimizer/test_search_space.py
+++ b/tests/flowboost/optimizer/test_search_space.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 from flowboost.openfoam.dictionary import DictionaryLink
-from flowboost.optimizer.search_space import Dimension
+from flowboost.optimizer.search_space import Dimension, _default_digits_for_bounds
 
 
 # Minimal DictionaryLink for constructing Dimension instances in tests
@@ -142,3 +142,56 @@ class TestDimensionCoerceValue:
         dim = Dimension.choice("s", _dummy_link(), ["a", "b", "c"])
         assert dim.value_type == "str"
         assert dim.coerce_value(42) == "42"
+
+
+class TestDefaultDigitsForBounds:
+    """Tests for the magnitude-aware default `digits` helper."""
+
+    @pytest.mark.parametrize(
+        "lower,upper,expected",
+        [
+            (500.0, 2000.0, 8),   # engineering range
+            (1.0, 100.0, 9),      # unit-scale
+            (0.1, 1.0, 11),       # sub-unit
+            (1e-9, 1e-7, 18),     # small-magnitude — must not round to zero
+            (-100.0, 100.0, 9),   # symmetric around zero
+            (0.0, 0.0, 12),       # degenerate — falls back to default
+        ],
+    )
+    def test_default_digits_scales_with_magnitude(self, lower, upper, expected):
+        assert _default_digits_for_bounds(lower, upper) == expected
+
+    def test_small_magnitude_bounds_are_not_zeroed(self):
+        """A value well inside [1e-9, 1e-7] must survive rounding intact."""
+        digits = _default_digits_for_bounds(1e-9, 1e-7)
+        value = 1.23456789e-8
+        assert round(value, digits) == pytest.approx(value, rel=1e-6)
+
+
+class TestDimensionRangeDefaultDigits:
+    """Range dimensions pick a sensible `digits` default for float dtypes."""
+
+    def test_float_range_gets_magnitude_aware_default(self):
+        dim = Dimension.range("x", _dummy_link(), 500.0, 2000.0)
+        assert dim.digits == 8
+
+    def test_explicit_digits_overrides_default(self):
+        dim = Dimension.range("x", _dummy_link(), 500.0, 2000.0, digits=4)
+        assert dim.digits == 4
+
+    def test_negative_digits_disables_rounding(self):
+        dim = Dimension.range("x", _dummy_link(), 500.0, 2000.0, digits=-1)
+        assert dim.digits is None
+
+    def test_int_range_leaves_digits_unset(self):
+        dim = Dimension.range("x", _dummy_link(), 0, 10, dtype=int)
+        assert dim.digits is None
+
+    def test_default_digits_collapse_float_noise(self):
+        """The practical purpose of the default: near-duplicate floats that BO
+        produces when converging on a box boundary must round to the same
+        value, so Ax's hash-based arm dedup can catch them."""
+        dim = Dimension.range("heatSource", _dummy_link(), 500.0, 2000.0)
+        noisy = [500.0, 500.0000000000001, 500.00000000000034]
+        rounded = {round(v, dim.digits) for v in noisy}
+        assert rounded == {500.0}

--- a/tests/flowboost/session/test_session_docker_integration.py
+++ b/tests/flowboost/session/test_session_docker_integration.py
@@ -1,3 +1,4 @@
+import math
 import os
 import time
 from pathlib import Path
@@ -91,6 +92,55 @@ def _wait_for_finished_job(manager: Manager, timeout_seconds: int = 180):
 
     tracked = ", ".join(sorted(job.name for job in manager.job_pool)) or "none"
     raise TimeoutError(f"Timed out waiting for DockerLocal job(s): {tracked}")
+
+
+def _drain_all_finished_jobs(manager: Manager, timeout_seconds: int = 300):
+    """Wait until ``manager.job_pool`` is fully drained, returning every
+    job that finished along the way."""
+    drained = []
+    while manager.job_pool:
+        drained.extend(_wait_for_finished_job(manager, timeout_seconds))
+    return drained
+
+
+def _build_multidim_pitzdaily_session(
+    tmp_path: Path, max_evaluations: int, job_limit: int
+) -> Session:
+    """Multi-dim variant: two linear `Dimension.range`s, both boundary-prone,
+    plus a configurable job parallelism for stressing batched acquisitions."""
+    session = Session(
+        name="pitzDaily-docker-multidim",
+        data_dir=tmp_path / "session_data",
+        max_evaluations=max_evaluations,
+    )
+
+    template = _configure_pitzdaily_case(session.data_dir / "pitzDaily_template")
+    session.attach_template_case(case=template)
+
+    objective = Objective(
+        name="inlet_pressure",
+        minimize=True,
+        objective_function=_pressure_drop_objective,
+        normalization_step="min-max",
+    )
+    session.backend.set_objectives([objective])
+
+    inlet_k = Dictionary.link("0/k").entry("boundaryField/inlet/value")
+    inlet_eps = Dictionary.link("0/epsilon").entry("boundaryField/inlet/value")
+    session.backend.set_search_space(
+        [
+            Dimension.range(name="inlet_k", link=inlet_k, lower=0.1, upper=1.5),
+            Dimension.range(name="inlet_eps", link=inlet_eps, lower=1.0, upper=100.0),
+        ]
+    )
+
+    session.job_manager = Manager.create(
+        scheduler="dockerlocal", wdir=session.data_dir, job_limit=job_limit
+    )
+    session.job_manager.monitoring_interval = 1
+    session.backend.initialization_trials = 2
+    session.clean_pending_cases()
+    return session
 
 
 def _build_pitzdaily_session(tmp_path: Path, max_evaluations: int) -> Session:
@@ -259,3 +309,200 @@ def test_session_tell_allows_duplicate_parameterizations_with_dockerlocal(
     assert list(session.backend.client.experiment.arms_by_name) == [
         finished_cases[0].name
     ]
+
+
+def _assert_session_invariants(
+    session: Session, *, expected_on_disk: int, expected_told: int
+) -> None:
+    """Invariants that should hold after any completed loop_optimizer cycle.
+
+    ``expected_on_disk`` is the number of archived cases on the filesystem.
+    ``expected_told`` is how many of those cases have been through tell() —
+    during a normal cycle this lags on-disk by one, since the just-archived
+    case doesn't get told until the next loop iteration.
+    """
+    backend = session.backend
+    dims = backend.dimensions
+
+    finished = session.get_finished_cases(include_failed=False, batch_process=True)
+    assert len(finished) == expected_on_disk, (
+        f"finished case count drift: expected {expected_on_disk}, "
+        f"got {len(finished)}"
+    )
+
+    # Objective metadata sanity — finite float for every completed case.
+    for case in finished:
+        metadata = case.read_metadata() or {}
+        raw_objectives = metadata.get("objective-values-raw", {})
+        for obj in backend.objectives:
+            value = raw_objectives.get(obj.name)
+            assert value is not None, f"no raw objective for {case.name}/{obj.name}"
+            value = float(value)
+            assert math.isfinite(value), (
+                f"non-finite objective for {case.name}/{obj.name}: {value}"
+            )
+
+    # Backend-side checks only apply to cases that have been told().
+    mapping = backend._trial_index_case_mapping
+    assert len(mapping) == expected_told, (
+        f"trial mapping size drift: expected {expected_told}, got {len(mapping)}"
+    )
+
+    # Count *completed* trials — after ask() the experiment also holds one
+    # pending Ax-generated trial for the next suggestion, which has its own
+    # auto-generated arm name and isn't in our mapping.
+    completed_trials = [
+        t
+        for t in backend.client.experiment.trials.values()
+        if t.status.is_completed
+    ]
+    assert len(completed_trials) == expected_told, (
+        f"completed trial count drift: expected {expected_told}, "
+        f"got {len(completed_trials)}"
+    )
+
+    trial_indices = set()
+    for case, idx in mapping.items():
+        assert idx not in trial_indices, (
+            f"duplicate trial index {idx} across told cases"
+        )
+        trial_indices.add(idx)
+
+        trial = backend.client.experiment.trials[idx]
+        assert trial.status.is_completed, (
+            f"case {case.name} mapped to non-completed trial {idx}"
+        )
+        assert trial.arm is not None
+
+        # Arm parameters must exactly match what the case says it was run at,
+        # after coercion + rounding. Any drift here means a tell()-time value
+        # diverged from the on-disk case — exactly the bug class #18 hides.
+        case_params = case.parametrize_configuration(dims)
+        assert trial.arm.parameters == case_params, (
+            f"arm↔case param drift for {case.name}: "
+            f"arm={trial.arm.parameters} case={case_params}"
+        )
+
+
+def _drive_one_cycle(session: Session) -> Case | None:
+    """Run loop_optimizer_once → submit → wait → archive. Returns the
+    archived case, or None if the optimizer declined to suggest anything."""
+    manager = session.job_manager
+    assert manager is not None
+
+    new_cases = session.loop_optimizer_once(num_new_cases=1)
+    if not new_cases:
+        return None
+    (case,) = new_cases
+
+    assert manager.submit_case(case)
+    job = _wait_for_finished_job(manager)[0]
+    dest = session.archival_dir / job.wdir.name
+    assert manager.move_data_for_job(job, dest)
+    archived = Case(dest)
+    archived.post_evaluation_update(job.to_dict())
+    return archived
+
+
+def test_session_docker_soak(docker_foam_runtime, tmp_path):
+    """End-to-end soak: run many full tell/ask cycles and assert invariants
+    after each one. Intended to surface state-management regressions that
+    unit tests don't catch (stale mappings, arm duplication, value drift,
+    persistence round-trips)."""
+    num_cycles = 12
+    session = _build_pitzdaily_session(tmp_path, max_evaluations=num_cycles)
+    session.backend.initialize()
+
+    completed = 0
+    for cycle in range(1, num_cycles + 1):
+        archived = _drive_one_cycle(session)
+        assert archived is not None, f"optimizer yielded nothing at cycle {cycle}"
+        completed += 1
+        # loop_optimizer_once tells cases from previous cycles before asking,
+        # so the just-archived case isn't in the mapping yet.
+        _assert_session_invariants(
+            session,
+            expected_on_disk=completed,
+            expected_told=completed - 1,
+        )
+
+    # Final flush: tell all completed cases so every archived case lands in
+    # the backend mapping, then run the full invariant battery with no lag.
+    # Pass batch_process=True to populate each case's objective outputs —
+    # tell() requires cases that have already been evaluated.
+    session.backend.tell(
+        session.get_finished_cases(include_failed=False, batch_process=True)
+    )
+    _assert_session_invariants(
+        session,
+        expected_on_disk=completed,
+        expected_told=completed,
+    )
+
+    # Persistence round-trip: rebuild a Session pointing at the same
+    # data_dir and confirm the finished-case set is fully recoverable.
+    restored = Session(
+        name="pitzDaily-docker-test",
+        data_dir=session.data_dir,
+        max_evaluations=num_cycles,
+    )
+    restored_finished = restored.get_finished_cases(include_failed=False)
+    assert len(restored_finished) == completed
+    assert {c.name for c in restored_finished} == {
+        c.name for c in session.get_finished_cases(include_failed=False)
+    }
+
+
+def test_session_docker_soak_multidim_parallel(docker_foam_runtime, tmp_path):
+    """End-to-end soak with a 2-dim linear search space running two cases
+    in parallel per cycle. Stresses batched attach/complete, pending-case
+    handling, and the new digits default on multi-dim BO convergence."""
+    batch_size = 2
+    num_cycles = 4
+    total_evaluations = batch_size * num_cycles
+    session = _build_multidim_pitzdaily_session(
+        tmp_path, max_evaluations=total_evaluations, job_limit=batch_size
+    )
+    session.backend.initialize()
+    manager = session.job_manager
+    assert manager is not None
+
+    # Sanity-check the precondition: default digits is applied to both dims.
+    assert all(dim.digits is not None for dim in session.backend.dimensions)
+
+    completed = 0
+    for cycle in range(1, num_cycles + 1):
+        new_cases = session.loop_optimizer_once(num_new_cases=batch_size)
+        assert len(new_cases) == batch_size, (
+            f"cycle {cycle} yielded {len(new_cases)} cases, expected {batch_size}"
+        )
+
+        for case in new_cases:
+            assert manager.submit_case(case)
+
+        finished_jobs = _drain_all_finished_jobs(manager)
+        assert len(finished_jobs) == batch_size
+
+        for job in finished_jobs:
+            dest = session.archival_dir / job.wdir.name
+            assert manager.move_data_for_job(job, dest)
+            Case(dest).post_evaluation_update(job.to_dict())
+
+        completed += batch_size
+        # On cycle 1 the tell() preceding ask() saw no finished cases, so the
+        # backend mapping still lags the on-disk count by `batch_size`.
+        _assert_session_invariants(
+            session,
+            expected_on_disk=completed,
+            expected_told=completed - batch_size,
+        )
+
+    # Final flush.
+    session.backend.tell(
+        session.get_finished_cases(include_failed=False, batch_process=True)
+    )
+    _assert_session_invariants(
+        session,
+        expected_on_disk=completed,
+        expected_told=completed,
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -841,7 +841,7 @@ wheels = [
 
 [[package]]
 name = "flowboost"
-version = "0.2.6"
+version = "0.2.7"
 source = { editable = "." }
 dependencies = [
     { name = "ax-platform", version = "1.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
- Default `digits` on float `Dimension.range`s and round in `coerce_value`, so BO-generated boundary near-duplicates (e.g. `500.0` vs `500.0000000000001`) collapse onto one arm and stop slipping past Ax's dedup — the actual root cause of #18.
- Replace three cryptic error paths surfaced by an end-to-end soak: `ask()` on a fresh backend, `tell()` on an unevaluated case, and `sys.exit` on optimizer completion (now a catchable `OptimizationComplete`).
- Add two Docker soak tests that drive `Session` through full tell/ask cycles — one single-dim persistence run, one 2-dim parallel-batch run that reproduces #18's pattern end-to-end.
- Bump to v0.2.7.

Tries to address findings in issue #18.