### PR TITLE
Replace AggregateObjective with ScalarizedObjective, drop normalization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ flowboost_data
 # Other files
 TODO.md
 
+# Agent harness dirs
+.claude
+
 # Custom instruction files
 AGENTS.md
 CLAUDE.md

--- a/examples/aerofoilNACA0012Steady/aerofoilNACA0012Steady.py
+++ b/examples/aerofoilNACA0012Steady/aerofoilNACA0012Steady.py
@@ -70,7 +70,6 @@ if __name__ == "__main__":
         name="L/D",
         minimize=False,
         objective_function=max_lift_drag_objective,
-        normalization_step="yeo-johnson",
     )
 
     session.backend.set_objectives([objective])

--- a/flowboost/__init__.py
+++ b/flowboost/__init__.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
     from flowboost.openfoam.dictionary import Dictionary as Dictionary
     from flowboost.openfoam.runtime import get_runtime as foam_runtime
     from flowboost.optimizer.objectives import (
-        AggregateObjective as AggregateObjective,
+        ScalarizedObjective as ScalarizedObjective,
         Objective as Objective,
     )
     from flowboost.optimizer.search_space import Dimension as Dimension
@@ -23,7 +23,7 @@ def __getattr__(name):
         "Dictionary": "flowboost.openfoam.dictionary",
         "Dimension": "flowboost.optimizer.search_space",
         "Objective": "flowboost.optimizer.objectives",
-        "AggregateObjective": "flowboost.optimizer.objectives",
+        "ScalarizedObjective": "flowboost.optimizer.objectives",
         "Manager": "flowboost.manager.manager",
         "Session": "flowboost.session.session",
         "foam_runtime": ("flowboost.openfoam.runtime", "get_runtime"),
@@ -42,7 +42,7 @@ def __getattr__(name):
 
 
 __all__ = [
-    "AggregateObjective",
+    "ScalarizedObjective",
     "Case",
     "Dictionary",
     "Dimension",

--- a/flowboost/openfoam/case.py
+++ b/flowboost/openfoam/case.py
@@ -22,7 +22,7 @@ from flowboost.optimizer.search_space import Dimension
 
 if TYPE_CHECKING:
     # Lazy imports for function argument typing
-    from flowboost.optimizer.objectives import AggregateObjective, Objective
+    from flowboost.optimizer.objectives import Objective, ScalarizedObjective
 
 DEFAULT_METADATA: str = "metadata.toml"
 GENERATION_INDEX_SORT_SENTINEL: str = "99999.99"
@@ -462,32 +462,30 @@ class Case:
         return entry.value
 
     def objective_function_outputs(
-        self, objectives: list[Union["Objective", "AggregateObjective"]]
+        self, objectives: list[Union["Objective", "ScalarizedObjective"]]
     ) -> dict[str, float]:
-        """Get the post-processed objective function outputs for this case.
+        """Return {metric_name: value} for every metric this case contributes.
 
-        Args:
-            objectives (list[&#39;Objective&#39;, &#39;AggregateObjective&#39;])
-
-        Returns:
-            dict[str, float]: Mapping of objective name to scalar output value
+        For a plain Objective the metric name is the objective's own name. For
+        a ScalarizedObjective each inner objective contributes its own metric
+        — Ax expects per-metric raw_data and does the scalarization itself.
         """
         output_mapping: dict[str, float] = {}
 
         for obj in objectives:
-            out = obj.data_for_case(self, post_processed=True)
-            if out is None:
+            metric_values = obj.metric_values_for_case(self)
+            if not metric_values:
                 raise ValueError(
-                    f"Objective '{obj.name}' has no post-processed output for "
-                    f"case {self}. The case has not been evaluated yet — run "
+                    f"Objective '{obj.name}' has no value for case {self}. The "
+                    f"case has not been evaluated yet — run "
                     f"Backend.batch_process([case]) first, or fetch finished "
                     f"cases via Session.get_finished_cases(batch_process=True)."
                 )
-
-            output_mapping[obj.name] = coerce_objective_scalar(
-                out,
-                label=f"Post-processed objective '{obj.name}' output",
-            )
+            for metric_name, value in metric_values.items():
+                output_mapping[metric_name] = coerce_objective_scalar(
+                    value,
+                    label=f"Objective '{metric_name}' output",
+                )
 
         return output_mapping
 

--- a/flowboost/optimizer/backend.py
+++ b/flowboost/optimizer/backend.py
@@ -6,8 +6,7 @@ from pathlib import Path
 from typing import Any, Union
 
 from flowboost.openfoam.case import Case
-from flowboost.optimizer.objectives import AggregateObjective, Objective
-from flowboost.optimizer.scalars import coerce_objective_scalar
+from flowboost.optimizer.objectives import Objective, ScalarizedObjective
 from flowboost.optimizer.search_space import Dimension
 
 DEFAULT_OFFLOAD_RESULT_FNAME = "acquisition_result.json"
@@ -16,7 +15,7 @@ DEFAULT_OFFLOAD_RESULT_FNAME = "acquisition_result.json"
 class Backend(ABC):
     def __init__(self) -> None:
         self.type: str = self.__class__.__name__
-        self.objectives: list[Union[Objective, AggregateObjective]] = []
+        self.objectives: list[Union[Objective, ScalarizedObjective]] = []
         self.dimensions: list[Dimension] = []
         self.offload_acquisition: bool = False
         self.random_seed: int | None = None
@@ -50,7 +49,7 @@ class Backend(ABC):
         pass
 
     @abstractmethod
-    def set_objectives(self, objectives: list[Union[Objective, AggregateObjective]]):
+    def set_objectives(self, objectives: list[Union[Objective, ScalarizedObjective]]):
         pass
 
     @abstractmethod
@@ -211,95 +210,49 @@ class Backend(ABC):
         pass
 
     def batch_process(self, cases: list[Case]) -> list[list[float]]:
-        """
-        Process a batch of cases through all objectives, applying any necessary
-        batch processing and aggregation, and return a list of lists of floats
-        suitable for optimization.
-        """
-        all_objective_outputs = []
+        """Evaluate every objective on `cases` and persist results to metadata.
 
-        # Step 1: Evaluate the objective functions
+        Returns a list-of-lists shaped [num_objectives][num_successful_cases].
+        For a ScalarizedObjective, the returned row is the scalarized value;
+        per-inner-metric values are still cached on each inner Objective for
+        the backend to retrieve when telling Ax.
+        """
         for objective in self.objectives:
             logging.info(f"Processing objective '{objective.name}'")
-            objective_outputs = objective.batch_evaluate(cases, save_values=False)
-            all_objective_outputs.append(objective_outputs)
+            objective.batch_evaluate(cases, save_values=True)
 
-        # Step 2: Ensure that no cases were marked as failed: if they did, remove them
-        # Remove None values from all_objective_outputs
-        successful_cases_indices = [
-            i for i, case in enumerate(cases) if case.success is not False
-        ]
-        all_objective_outputs = [
-            [
-                output
-                for i, output in enumerate(objective_outputs)
-                if i in successful_cases_indices
-            ]
-            for objective_outputs in all_objective_outputs
-        ]
-
-        # Update logging to reflect the removal of failed cases
-        logging.info(
-            f"Removed failed cases: proceeding with {len(successful_cases_indices)} successful case(s)"
-        )
-
-        if len(successful_cases_indices) == 0:
+        successful_cases = [c for c in cases if c.success is not False]
+        logging.info(f"Proceeding with {len(successful_cases)} successful case(s)")
+        if not successful_cases:
             return []
-        # Step 3: Execute post-processing steps for only successful cases
-        final_outputs = []
-        raw_outputs = []  # Add this to store raw values
-        for i, objective in enumerate(self.objectives):
-            logging.info(f"Post-processing objective '{objective.name}' outputs.")
-            # Filter cases and their outputs for successful cases only
-            successful_cases = [cases[i] for i in successful_cases_indices]
-            successful_outputs = all_objective_outputs[i]
 
-            # Store raw outputs before post-processing
-            raw_outputs.append(successful_outputs)
+        # Values were coerced to float at evaluate() time; data_for_case is
+        # an unwrapped lookup, no re-coercion needed.
+        final_outputs: list[list[float]] = [
+            [objective.data_for_case(c) for c in successful_cases]
+            for objective in self.objectives
+        ]
 
-            # Execute post-processing
-            post_processed_outputs = objective.batch_post_process(
-                successful_cases, successful_outputs, save_values=True
-            )
-            final_outputs.append(post_processed_outputs)
-
-        # Step 4: Save both raw and final objective outputs to case metadata
         for case_idx, case in enumerate(successful_cases):
-            objective_results = {}
-            raw_objective_results = {}
+            objective_results: dict[str, Any] = {}
             for obj_idx, objective in enumerate(self.objectives):
-                # Post-processed value
-                value = coerce_objective_scalar(
-                    final_outputs[obj_idx][case_idx],
-                    label=f"Post-processed objective '{objective.name}' output",
-                )
                 objective_results[objective.name] = {
-                    "value": value,
+                    "value": final_outputs[obj_idx][case_idx],
                     "minimize": objective.minimize,
                 }
-
-                # Raw value (before post-processing)
-                raw_output = raw_outputs[obj_idx][case_idx]
-                if isinstance(objective, AggregateObjective):
-                    raw_output = objective.aggregate_outputs([raw_output])[0]
-
-                raw_objective_results[objective.name] = coerce_objective_scalar(
-                    raw_output,
-                    label=f"Raw objective '{objective.name}' output",
-                )
-
-            # Save post-processed values
+                if isinstance(objective, ScalarizedObjective):
+                    objective_results[objective.name]["components"] = {
+                        inner.name: inner.data_for_case(case)
+                        for inner in objective.objectives
+                    }
             case.update_metadata(objective_results, entry_header="objective-outputs")
-            # Save raw values
-            case.update_metadata(
-                raw_objective_results, entry_header="objective-values-raw"
-            )
             logging.debug(f"Saved objective outputs to metadata for {case.name}")
+
         return final_outputs
 
     def _objective_name_to_objective(
         self, objective_name: str
-    ) -> Union[Objective, AggregateObjective]:
+    ) -> Union[Objective, ScalarizedObjective]:
         """
         Args:
             objective_name (str): Objective name to map to the corresponding \
@@ -309,7 +262,7 @@ class Backend(ABC):
             ValueError: _description_
 
         Returns:
-            Union[Objective, AggregateObjective]: An Objective
+            Union[Objective, ScalarizedObjective]: An Objective
         """
         for objective in self.objectives:
             if objective.name == objective_name:

--- a/flowboost/optimizer/interfaces/Ax.py
+++ b/flowboost/optimizer/interfaces/Ax.py
@@ -10,9 +10,12 @@ from ax.core.base_trial import BaseTrial
 from ax.exceptions.core import DataRequiredError
 from ax.service.ax_client import AxClient, ObjectiveProperties, TParameterization
 
+from ax.core.objective import ScalarizedObjective as AxScalarizedObjective
+from ax.core.optimization_config import OptimizationConfig
+
 from flowboost.openfoam.case import Case
 from flowboost.optimizer.backend import Backend, OptimizationComplete
-from flowboost.optimizer.objectives import AggregateObjective, Objective
+from flowboost.optimizer.objectives import Objective, ScalarizedObjective
 from flowboost.optimizer.scalars import coerce_objective_scalar
 from flowboost.optimizer.search_space import Dimension
 
@@ -104,6 +107,19 @@ class AxBackend(Backend):
                 # total in-flight jobs externally.
                 "enforce_sequential_optimization": False,
             },
+        )
+
+        self._maybe_install_scalarized_objective()
+
+        # Outcome standardization is handled by Ax: the BoTorch generator's
+        # default transform stack applies BilogY → StandardizeY before model
+        # fit, and BoTorch's SingleTaskGP wraps outcomes in its own
+        # Standardize. Some Ax versions also add Winsorize. Don't add a
+        # normalization layer in your Objective.
+        logging.info(
+            "Ax handles outcome normalization (BilogY → StandardizeY → "
+            "GP.Standardize; Winsorize may be present depending on Ax version). "
+            "No flowboost-side transforms needed."
         )
 
         logging.info("Ax experiment initialized")
@@ -260,9 +276,19 @@ class AxBackend(Backend):
         self._trial_index_case_mapping = {}
         self.initialize()
 
-    def set_objectives(self, objectives: list[Union[Objective, AggregateObjective]]):
-        if isinstance(objectives, (Objective, AggregateObjective)):
+    def set_objectives(
+        self, objectives: Union[Objective, ScalarizedObjective, list[Objective]]
+    ):
+        if isinstance(objectives, (Objective, ScalarizedObjective)):
             objectives = [objectives]
+        if (
+            any(isinstance(o, ScalarizedObjective) for o in objectives)
+            and len(objectives) > 1
+        ):
+            raise ValueError(
+                "ScalarizedObjective must be the only top-level objective; "
+                "mixing it with other objectives is not supported."
+            )
         self.objectives = objectives
 
     def set_search_space(self, dimensions: list[Dimension]):
@@ -587,13 +613,55 @@ class AxBackend(Backend):
             )
 
     def _get_ax_objectives(self) -> dict[str, ObjectiveProperties]:
+        """Build the per-metric registration passed to AxClient.create_experiment.
+
+        For top-level Objectives, the objective is the metric. For a top-level
+        ScalarizedObjective, each inner Objective is registered as its own
+        metric so Ax models them independently; the single-objective scalarized
+        OptimizationConfig is then installed by `_maybe_install_scalarized_objective`.
+        """
         ax_objectives: dict[str, ObjectiveProperties] = {}
         for objective in self.objectives:
-            ax_objectives[objective.name] = ObjectiveProperties(
-                minimize=objective.minimize, threshold=objective.threshold
-            )
+            if isinstance(objective, ScalarizedObjective):
+                for inner in objective.objectives:
+                    ax_objectives[inner.name] = ObjectiveProperties(
+                        minimize=inner.minimize, threshold=inner.threshold
+                    )
+            else:
+                ax_objectives[objective.name] = ObjectiveProperties(
+                    minimize=objective.minimize, threshold=objective.threshold
+                )
 
         return ax_objectives
+
+    def _maybe_install_scalarized_objective(self) -> None:
+        """Swap in Ax's native ScalarizedObjective when the user asked for one.
+
+        AxClient.create_experiment treats multi-metric input as MOO by default;
+        we override the optimization_config so the inner metrics are scalarized
+        at the acquisition step. Each metric still has its own surrogate and
+        its own StandardizeY — that's the win over computing the weighted sum
+        upstream.
+        """
+        scalarized = [o for o in self.objectives if isinstance(o, ScalarizedObjective)]
+        if not scalarized:
+            return
+
+        flowboost_obj = scalarized[0]
+        # Reuse the Metric objects Ax already registered for the inner
+        # objectives in `_get_ax_objectives`; constructing fresh ones here
+        # would re-encode `lower_is_better` and invite the two paths to drift.
+        metrics = [
+            self.client.experiment.metrics[inner.name]
+            for inner in flowboost_obj.objectives
+        ]
+        self.client.experiment.optimization_config = OptimizationConfig(
+            objective=AxScalarizedObjective(
+                metrics=metrics,
+                weights=flowboost_obj.weights,
+                minimize=flowboost_obj.minimize,
+            )
+        )
 
     def _dim_to_Ax_parameter_dict(self, dim: Dimension) -> dict[str, Any]:
         d: dict[str, Any] = {

--- a/flowboost/optimizer/objectives.py
+++ b/flowboost/optimizer/objectives.py
@@ -1,9 +1,7 @@
 import logging
-from typing import Any, Callable, Optional
+import math
+from typing import Any, Callable, Optional, Union
 from uuid import uuid4
-
-import numpy as np
-from sklearn.preprocessing import MinMaxScaler, PowerTransformer
 
 from flowboost.openfoam.case import Case
 from flowboost.optimizer.scalars import coerce_objective_scalar
@@ -11,7 +9,14 @@ from flowboost.optimizer.scalars import coerce_objective_scalar
 
 class Objective:
     """A named optimization objective that evaluates a Case and returns a
-    scalar value. Supports minimization/maximization and optional normalization."""
+    scalar value.
+
+    Outcome standardization is the optimizer backend's job (Ax wraps every
+    metric in StandardizeY + BoTorch's Standardize). Don't add normalization
+    here. If your measurement is naturally non-linear (log-distributed drag,
+    say), pass `static_transform=math.log` — a pure float→float function,
+    applied per evaluation, no fitting, no state.
+    """
 
     def __init__(
         self,
@@ -19,262 +24,107 @@ class Objective:
         minimize: bool,
         objective_function: Callable,
         objective_function_kwargs: Optional[dict[str, Any]] = None,
-        normalization_step: Optional[str] = None,
         threshold: Optional[float] = None,
+        static_transform: Optional[Callable[[float], float]] = None,
     ) -> None:
-        """ An optimization objective that produces a quantifiable result for
-        an OpenFOAM simulation. An Objective operates on an objective function,
-        usings its evaluated value for informing the optimization process.
-
-        The objective function is expected to return something that is, ideally,
-        simply a scalar value. However, as you may define an arbitrary
-        post-processing step for the Objective, operating on the output vector
-        the Objective produces from all data points, the output can be arbitrary.
-
-        More specifically:
-        1) Objective consumes data (pd.DataFrame) for OpenFOAM Case
-        2) `objective_function` operates on the data, returning an arbitrary
-        value which is associated with the Case.
-        3) Any values returned by `objective_function` can be later accesses as
-        a vector, composed of the outputs of Objective for each OpenFOAM case.
-
-        Additionally, you may pass arbitrary (constant) data to the function
-        you have defined. This can be a DataFrame of reference data for a
-        baseline simulation, or something completely different.
+        """An optimization objective for an OpenFOAM simulation.
 
         Args:
-            name (str): Name or description for this objective
-            minimize (bool): Optimization objective: is the objective \
-                function to be minimized, maximized, or something else?
-            objective_function (Callable): An objective function for  \
-                computing a quantified value. Function should accept at least \
-                    one argument (Case), and potentially additional kwargs.
-            objective_function_kwargs (dict, optional): Arbitrary additional \
-                data passed to objective_function as kwargs. Defaults to {}.
-            threshold (float, optional): Optional threshold value for MOO \
-                objectives (see Ax documentation). Defaults to None.
+            name: Identifier for the objective. Must be unique across all
+                metrics in the experiment (including those wrapped in a
+                ScalarizedObjective).
+            minimize: True to minimize, False to maximize.
+            objective_function: Callable taking a Case (and optional kwargs)
+                and returning a scalar. Returning None marks the case failed.
+            objective_function_kwargs: Extra kwargs passed through to
+                `objective_function` on every call.
+            threshold: Optional MOO objective threshold (see Ax docs). Only
+                used by backends that support multi-objective Pareto fronts.
+            static_transform: Optional pure float→float transform applied to
+                each scalar output. Use for domain-driven re-expressions
+                (e.g. `math.log` for a log-distributed quantity). Not for
+                normalization — the backend handles that.
         """
         self.name: str = name
         self.id: str = str(uuid4())
-
-        # Goal for optimization task
         self.minimize: bool = minimize
-
-        # Objective threshold: this is used by Ax during MOO, and is not
-        # leveraged by all backends.
-        #
-        # For any objective function to be maximized, represents the _lowest_
-        # objective value that is considered valuable in the context of
-        # multi-objective optimization. Applies in the opposite manner for
-        # objectives that are to be minimized.
         self.threshold: Optional[float] = threshold
-
-        # User-provided function instance performing arbitrary computation
-        # on a Pandas DataFrame, and returning some comparable result that
-        # can be used during the optimization process.
         self.objective_function: Callable = objective_function
-
-        # Additional data that gets passed to the objective function. This can
-        # be anything, potentially an aggregated DataFrame for a baseline
-        # simulation used for comparisons, or something more esoteric.
         self.objective_function_kwargs: dict[str, Any] = dict(
             objective_function_kwargs or {}
         )
+        self.static_transform: Optional[Callable[[float], float]] = static_transform
 
-        # Any post-processing steps to be completed for this objective.
-        # Post-processing is performed once _all_ Case objects have had the
-        # objective_function evaluated: the post processing function thus gets
-        # passed a vector of all results from the Objective outputs for each
-        # Case.
-        #
-        # The steps are defined as a tuple of (Callable, arg1, arg2, ...),
-        # where the args get unpacked and automatically passed to the
-        # post-processing function during evaluation.
-        self._post_processing_steps: list[tuple[Callable, Any]] = []
+        self._values: dict[Case, float] = {}
 
-        # Data storage for each case that gets evaluated by this objective.
-        # Raw outputs may be arbitrary, but post-processed outputs must be
-        # scalar numerics suitable for optimization backends.
-        self._objective_output_data: dict[Case, Any] = {}
-        self._post_processed_data: dict[Case, float] = {}
+    def evaluate(self, case: Case, save_value: bool = True) -> Optional[float]:
+        """Evaluate the objective for a single case.
 
-        if normalization_step:
-            self.add_normalization_step(method=normalization_step)
-
-    def add_normalization_step(self, method: str) -> None:
-        """Simple high-level method of integrating a normalization step to the
-        objective pipeline. The methods are from `sklearn.preprocessing`.
-
-        The normalization step is performed once all points in the dataset have
-        been evaluated using this Objective function. The input is, thus, the
-        array of outputs this Objective has generated.
-
-        For custom normalization steps not supported by this function, use the
-        `Objective.attach_post_processing_step()` method, which accepts any
-        arbitrary Callable + kwargs.
-
-        Args:
-            method (Literal): Normalization method to use: min-max or power-transform.
-
-        Raises:
-            ValueError: If method is not implemented
-        """
-        match method.lower():
-            case "min-max":
-                normalizer = MinMaxScaler()
-            case "yeo-johnson":
-                normalizer = PowerTransformer(method="yeo-johnson")
-            case "box-cox":
-                normalizer = PowerTransformer(method="box-cox")
-            case _:
-                logging.warning(
-                    "For custom normalization methods, use `attach_post_processing_step`"
-                )
-                raise ValueError(f"Unsupported normalization method '{method}'")
-
-        self.attach_post_processing_step(
-            step=ScikitNormalizationStep(normalizer).evaluate
-        )
-
-    def attach_post_processing_step(self, step: Callable, **kwargs: Any) -> None:
-        """Add a new post-processing step to this Objective. The post-processing
-        steps are evaluated in order of `Objective._post_processing_steps`: thus,
-        the order they are added in matters.
-
-        A typical use-case would be a normalization step.
-
-        Args:
-            step (Callable): _description_
-        """
-        self._post_processing_steps.append((step, kwargs))
-
-    def execute_post_processing_steps(
-        self, cases: list[Case], outputs: list[Any], save_output: bool = True
-    ) -> dict[Case, float]:
-        if len(outputs) != len(cases):
-            raise ValueError(
-                f"Case count != output count: cases={cases}, outputs={outputs}"
-            )
-
-        if len(outputs) == 0:
-            return {}
-
-        # Iterate over post-processing steps
-        for step, kwargs in self._post_processing_steps:
-            # Apply the step to the entire array of outputs
-            # Consider using try-except to handle errors gracefully
-            try:
-                outputs = step(outputs, **kwargs)
-            except Exception as e:
-                raise ValueError(f"Error applying post-processing step {step}: {e}")
-
-            try:
-                output_count = len(outputs)
-            except TypeError as e:
-                raise ValueError(
-                    f"Post-processing step {step} must return a sized collection: {e}"
-                )
-
-            if output_count != len(cases):
-                raise ValueError(
-                    f"Post-processing step {step} changed output cardinality: "
-                    f"expected {len(cases)}, got {output_count}"
-                )
-
-        # Optionally, save post-processed outputs back to a dictionary keyed by Case
-        # if specific per-case post-processed data is needed for further analysis
-        out_dict: dict[Case, float] = {}
-        for case, processed_output in zip(cases, outputs):
-            out_dict[case] = coerce_objective_scalar(
-                processed_output,
-                label=f"Post-processed objective '{self.name}' output",
-            )
-
-        if save_output:
-            self._post_processed_data = out_dict
-
-        return out_dict
-
-    def evaluate(self, case: Case, save_value: bool = True) -> Optional[Any]:
-        """
-        Evaluates the objective function for a case, returning the output
-        value. If the objective function returns a None-type, the value is
-        not saved to the objective to avoid post-processing failures.
-
-        Args:
-            case (Case): _description_
-            save_value (bool, optional): _description_. Defaults to True.
-
-        Returns:
-            Any: Value of the objective function output for a successful case: \
-                None indicates an evaluation failure.
+        Returns the (optionally transformed) scalar, or None if the case
+        failed or the objective function returned None.
         """
         if case.success is False:
             logging.warning("Case has been marked as failed: not evaluating objective")
             return None
 
         if self.objective_function_kwargs:
-            out = self.objective_function(case, **self.objective_function_kwargs)
+            raw = self.objective_function(case, **self.objective_function_kwargs)
         else:
-            out = self.objective_function(case)
+            raw = self.objective_function(case)
 
-        if out is None:
-            # Failures are not stored in the objective
+        if raw is None:
             logging.warning(f"Objective function returned a None for {case}")
             logging.warning("Marking case as failed and not storing output!")
             case.mark_failed()
             return None
 
+        value = self.static_transform(raw) if self.static_transform else raw
+        value = coerce_objective_scalar(value, label=f"Objective '{self.name}' output")
+
         if save_value:
-            self._objective_output_data[case] = out
+            self._values[case] = value
 
-        return out
-
-    def data_for_case(self, case: Case, post_processed: bool = True) -> Any:
-        """Reads objective output for a Case, either from before or after
-        the post-processing step.
-
-        WARN: This function does _not_ re-apply the post-processing step.
-
-        Args:
-            case (Case): _description_
-            post_processed (bool, optional): _description_. Defaults to False.
-
-        Returns:
-            Any: Objective output, None if not found.
-        """
-        if post_processed:
-            return self._post_processed_data.get(case, None)
-
-        return self._objective_output_data.get(case, None)
+        return value
 
     def batch_evaluate(
-        self, cases: list[Case], save_values: bool = False
-    ) -> list[Optional[Any]]:
-        # Evaluate for each case
+        self, cases: list[Case], save_values: bool = True
+    ) -> list[Optional[float]]:
         return [self.evaluate(case=case, save_value=save_values) for case in cases]
 
-    def batch_post_process(
-        self, cases: list[Case], outputs: list[Any], save_values: bool = True
-    ) -> list[float]:
-        out_d = self.execute_post_processing_steps(
-            cases=cases, outputs=outputs, save_output=save_values
+    def data_for_case(self, case: Case) -> Optional[float]:
+        """Return the cached evaluated value for a case, or None if not seen."""
+        return self._values.get(case)
+
+    def metric_values_for_case(self, case: Case) -> dict[str, float]:
+        """Return {metric_name: value} contributed by this objective for `case`.
+
+        Used by the backend to build `raw_data` for `tell()`. An empty dict
+        signals "no value available" (case failed or not yet evaluated).
+        """
+        v = self.data_for_case(case)
+        return {} if v is None else {self.name: v}
+
+
+class ScalarizedObjective:
+    """A weighted sum of multiple Objectives, optimized as a single scalar.
+
+    Direction is encoded by signed weights: a negative weight flips the
+    contribution of an inner objective relative to the formula. The outer
+    `minimize` flag then says whether to minimize or maximize the resulting
+    sum.
+
+    Example: maximize lift-to-drag ratio
+        lift = Objective(name="lift", minimize=False, ...)
+        drag = Objective(name="drag", minimize=True,  ...)
+        ratio = ScalarizedObjective(
+            name="LiftToDrag", minimize=False,
+            objectives=[lift, drag], weights=[0.7, -0.3],
         )
-        return list(out_d.values())
 
-
-class AggregateObjective:
-    # TODO make this a super of Objective
-    """An AggregateObjective serves as an aggregator for multiple Objectives, in
-    scenarios where the underlying optimizer either supports only one optimization
-    objective, or an otherwise finite number of them.
-
-    This wrapper allows for multiple, typically similar, objectives to be merged
-    into one, scalar value, according to some weighting rules the user specifies.
-
-    The underlying setup is identical to that of an Objective, with the exception
-    of the post-processing steps being applied on a _tuple_ of all Objective
-    outputs this AggregateObjective wraps within itself.
+    With a backend that supports it (e.g. AxBackend), each inner objective
+    becomes its own metric in the surrogate, gets standardized independently,
+    and the weighted sum is computed at the acquisition step. With backends
+    that don't, scalarization happens at the flowboost layer.
     """
 
     def __init__(
@@ -282,232 +132,168 @@ class AggregateObjective:
         name: str,
         minimize: bool,
         objectives: list[Objective],
-        threshold: float,
         weights: Optional[list[float]] = None,
     ) -> None:
-        """Initialize a new, aggregated AggregateObjective.
+        if not objectives:
+            raise ValueError("ScalarizedObjective requires at least one objective")
 
-        Args:
-            objectives (list[Objective]): Objectives to aggregate
-            weights (Optional[list[float]], optional): Optional weights for aggregation step. Defaults to None.
+        for i, obj in enumerate(objectives):
+            if isinstance(obj, ScalarizedObjective):
+                raise TypeError(
+                    f"ScalarizedObjective.objectives[{i}] is itself a "
+                    f"ScalarizedObjective. Nested scalarization is not "
+                    f"supported — flatten into one ScalarizedObjective with "
+                    f"the combined inner objectives and weights."
+                )
+            if not isinstance(obj, Objective):
+                raise TypeError(
+                    f"ScalarizedObjective.objectives[{i}] must be an "
+                    f"Objective, got {type(obj).__name__!r}. Constraints and "
+                    f"other metric types cannot be scalarized."
+                )
 
-        Raises:
-            ValueError: _description_
-        """
+        names = [o.name for o in objectives]
+        duplicates = sorted({n for n in names if names.count(n) > 1})
+        if duplicates:
+            raise ValueError(
+                f"ScalarizedObjective has duplicate inner objective names: "
+                f"{duplicates}. Each inner metric must be uniquely named — "
+                f"Ax registers each as its own metric on the experiment. "
+                f"(If you intended two distinct terms, give them different "
+                f"names; if you passed the same Objective instance twice, "
+                f"drop the duplicate.)"
+            )
+
+        if any(o.threshold is not None for o in objectives):
+            raise ValueError(
+                "Inner Objective.threshold is not honored when wrapped in a "
+                "ScalarizedObjective: scalarization collapses to a single "
+                "objective so per-metric Pareto thresholds don't apply. Drop "
+                "the threshold or use plain Objectives in MOO mode instead."
+            )
+
         self.name: str = name
         self.minimize: bool = minimize
         self.objectives: list[Objective] = objectives
         self.weights: list[float] = (
-            weights if weights is not None else [1.0] * len(objectives)
+            list(weights) if weights is not None else [1.0] * len(objectives)
         )
-        self.threshold: Optional[float] = threshold
-
-        self._post_processing_steps: list[tuple[Callable, dict[str, Any]]] = []
-
-        # Data storage for each case that gets evaluated by this objective.
-        # Raw outputs may be tuples across objectives, but the final aggregated
-        # values stored for backends are scalar numerics.
-        self._objective_output_data: dict[Case, Any] = {}
-        self._post_processed_data: dict[Case, float] = {}
-
-        if len(self.objectives) == 0:
-            raise ValueError("AggregateObjective requires at least one objective")
 
         if len(self.weights) != len(self.objectives):
             raise ValueError("Length of weights must match number of objectives")
 
-    def attach_post_processing_step(self, step: Callable, **kwargs: dict[str, Any]):
-        """Attach a post-processing step for this AggregateObjective. Post-processing
-        steps are evaluated PRIOR to the aggregation step, operating on a list
-        of tuples, each tuple representing the outputs for one processed Case's
-        AggregateObjective output.
+        for i, w in enumerate(self.weights):
+            if not math.isfinite(w):
+                raise ValueError(
+                    f"ScalarizedObjective weight at index {i} is not finite "
+                    f"({w!r}). Weights must be finite floats — NaN and ±inf "
+                    f"are rejected."
+                )
 
-        The input should thus be list[tuple[Any * len(AggregateObjective.objectives)]]
+        if all(w == 0.0 for w in self.weights):
+            raise ValueError(
+                "ScalarizedObjective has no non-zero weights; the "
+                "scalarization has no signal. Drop the wrapper, or set at "
+                "least one non-zero weight."
+            )
 
-        Args:
-            step (Callable): Post-processing function
+        # Each inner objective declared a direction (minimize or not). The
+        # weight's sign in a scalarization implies a direction too: with
+        # outer minimize=M, a positive weight means "this term's direction
+        # equals M", a negative weight means "opposite of M". Reject when
+        # those disagree — the optimization is internally inconsistent and
+        # Ax would otherwise reject it deep in the surrogate setup. Weight
+        # zero is a direction-less term; warn and skip the direction check
+        # so users can temporarily mute a contribution during tuning.
+        for obj, w in zip(self.objectives, self.weights):
+            if w == 0.0:
+                logging.warning(
+                    f"ScalarizedObjective {self.name!r}: inner objective "
+                    f"{obj.name!r} has weight 0 — its contribution is "
+                    f"disabled. Set a non-zero weight to re-enable."
+                )
+                continue
+            implied_minimize = self.minimize if w > 0 else not self.minimize
+            if obj.minimize != implied_minimize:
+                obj_dir = "minimize" if obj.minimize else "maximize"
+                implied_dir = "minimize" if implied_minimize else "maximize"
+                raise ValueError(
+                    f"Inconsistent direction for inner objective {obj.name!r}: "
+                    f"weight={w:+g} with outer minimize={self.minimize} implies "
+                    f"'{implied_dir}', but the objective declares '{obj_dir}'. "
+                    f"Flip the sign of the weight or the inner objective's "
+                    f"minimize flag."
+                )
+
+        # Threshold is single-objective-mode only (no Pareto front to bound).
+        # Kept as a None attribute so call sites that read it don't break.
+        self.threshold: Optional[float] = None
+
+        self._values: dict[Case, float] = {}
+
+    def evaluate(self, case: Case, save_value: bool = True) -> Optional[float]:
+        """Evaluate every inner objective and return the signed weighted sum.
+
+        Inner evaluation results are cached on each inner Objective (so
+        `inner.data_for_case(case)` works after this call). If any inner
+        returns None, the whole scalarization is None.
         """
-        self._post_processing_steps.append((step, kwargs))
-
-    def evaluate(
-        self, case: Case, save_value: bool = True
-    ) -> Optional[tuple[Any, ...]]:
         if case.success is False:
             logging.warning("Case has been marked as failed: not evaluating objective")
             return None
 
-        objective_outputs = [
+        inner_values = [
             obj.evaluate(case, save_value=save_value) for obj in self.objectives
         ]
-
-        if any(output is None for output in objective_outputs):
+        if any(v is None for v in inner_values):
             return None
 
-        output_tuple = tuple(objective_outputs)
-        if save_value:
-            self._objective_output_data[case] = list(output_tuple)
-
-        return output_tuple
-
-    def _evaluate_batch(
-        self, cases: list[Case], save_values: bool = False
-    ) -> list[Optional[tuple[Any, ...]]]:
-        all_outputs = [self.evaluate(case, save_value=save_values) for case in cases]
-        return all_outputs
-
-    def batch_evaluate(
-        self, cases: list[Case], save_values: bool = False
-    ) -> list[Optional[tuple[Any, ...]]]:
-        return self._evaluate_batch(cases, save_values=save_values)
-
-    def apply_batch_post_processing(self, all_outputs: list[tuple]) -> list[tuple]:
-        # Apply post-processing steps suitable for batch-level processing
-        # Example: normalization across each element of the tuples
-        expected_count = len(all_outputs)
-        for step, kwargs in self._post_processing_steps:
-            try:
-                transformed_columns = []
-                for output in zip(*all_outputs):
-                    transformed = step(output, **kwargs)
-                    try:
-                        transformed_count = len(transformed)
-                    except TypeError as e:
-                        raise ValueError(
-                            f"Post-processing step {step} must return a sized collection: {e}"
-                        )
-
-                    if transformed_count != expected_count:
-                        raise ValueError(
-                            f"Post-processing step {step} changed output cardinality: "
-                            f"expected {expected_count}, got {transformed_count}"
-                        )
-
-                    transformed_columns.append(list(transformed))
-
-                # Transpose back if needed
-                all_outputs = [tuple(row) for row in zip(*transformed_columns)]
-            except Exception as e:
-                raise ValueError(
-                    f"Error applying batch post-processing step {step}: {e}"
-                )
-        return all_outputs
-
-    def aggregate_outputs(self, processed_outputs: list[tuple]) -> list[float]:
-        """Aggregate the post-processed tuple outputs into scalar values."""
-        aggregated_values = [
-            sum(
-                float(output * weight)
-                for output, weight in zip(obj_outputs, self.weights)
-            )
-            for obj_outputs in processed_outputs
-        ]
-        return aggregated_values
-
-    def batch_post_process(
-        self,
-        cases: list[Case],
-        outputs: list[tuple[Any, ...]],
-        save_values: bool = True,
-    ) -> list[float]:
-        if len(outputs) != len(cases):
-            raise ValueError(
-                f"Case count != output count: cases={cases}, outputs={outputs}"
-            )
-
-        if not outputs:
-            return []
-
-        processed_outputs = self.apply_batch_post_processing(outputs)
-        aggregated_outputs = [
-            coerce_objective_scalar(
-                out,
-                label=f"Post-processed aggregate objective '{self.name}' output",
-            )
-            for out in self.aggregate_outputs(processed_outputs)
-        ]
-
-        if save_values:
-            self._post_processed_data = {
-                case: out for case, out in zip(cases, aggregated_outputs)
-            }
-
-        return aggregated_outputs
-
-    def batch_process(self, cases: list[Case], save_values: bool = True) -> list[float]:
-        all_outputs = self.batch_evaluate(cases, save_values=save_values)
-        successful = [
-            (case, output)
-            for case, output in zip(cases, all_outputs)
-            if case.success is not False and output is not None
-        ]
-
-        if not successful:
-            return []
-
-        successful_cases = [case for case, _ in successful]
-        successful_outputs = [output for _, output in successful]
-        return self.batch_post_process(
-            successful_cases, successful_outputs, save_values=save_values
+        scalar = sum(w * v for w, v in zip(self.weights, inner_values))
+        scalar = coerce_objective_scalar(
+            scalar, label=f"ScalarizedObjective '{self.name}' output"
         )
 
-    def data_for_case(self, case: Case, post_processed: bool = True):
-        if post_processed:
-            return self._post_processed_data.get(case, None)
+        if save_value:
+            self._values[case] = scalar
 
-        return self._objective_output_data.get(case, None)
+        return scalar
+
+    def batch_evaluate(
+        self, cases: list[Case], save_values: bool = True
+    ) -> list[Optional[float]]:
+        return [self.evaluate(case=case, save_value=save_values) for case in cases]
+
+    def data_for_case(self, case: Case) -> Optional[float]:
+        """Return the cached scalarized value for a case."""
+        return self._values.get(case)
+
+    def metric_values_for_case(self, case: Case) -> dict[str, float]:
+        """Return {inner_metric_name: value} for each inner objective.
+
+        These are the per-metric values backends with native scalarization
+        (e.g. Ax) expect — Ax does the weighted sum itself at the acquisition
+        step.
+        """
+        out: dict[str, float] = {}
+        for obj in self.objectives:
+            v = obj.data_for_case(case)
+            if v is None:
+                return {}
+            out[obj.name] = v
+        return out
 
 
 def objective_func_output(
     case: Case,
-    objective: Objective,
-    post_processed: bool = False,
+    objective: Union[Objective, "ScalarizedObjective"],
     re_evaluate: bool = False,
-):
-    """Get the objective function (Objective) output for this case. The
-    default setting, `post_processed=False`, returns the raw objective
-    output, prior to any post-processing steps such as normalization.
+) -> Optional[float]:
+    """Read the cached output of `objective` for `case`.
 
-    WARN: re-evaluating the data with post_processed=True can be extremely
-    slow, depending on your post-processing flow. This typically entails
-    evaluating the objective function for all cases.
-
-    Args:
-        objective (Objective): _description_
-        post_processed (bool, optional): _description_. Defaults to False.
-        re_evaluate (bool, optional): _description_. Defaults to False.
-
-    Returns:
-        _type_: _description_
+    For ScalarizedObjective this returns the scalarized value. To inspect
+    individual inner contributions, iterate `objective.objectives` and call
+    `inner.data_for_case(case)` on each.
     """
-    if isinstance(objective, AggregateObjective):
-        raise NotImplementedError(
-            "Cannot evaluate AggregateObjectives through Case methods"
-        )
-
-    if re_evaluate and post_processed:
-        # TODO: objective has all data, so just re-run postproc step?
-        raise NotImplementedError(
-            "Cannot re-evaluate while accessing post-processed data"
-        )
-
     if re_evaluate:
         objective.evaluate(case)
-
-    return objective.data_for_case(case, post_processed=post_processed)
-
-
-class ScikitNormalizationStep:
-    """
-    Class serves as a very simple wrapper around Scikit's normalization
-    functions that can be directly dropped into the objective's post-processing
-    steps.
-    """
-
-    def __init__(self, scikit_normalizer) -> None:
-        if not hasattr(scikit_normalizer, "fit_transform"):
-            raise ValueError("Normalizer does not have fit_transform method")
-        self.normalizer = scikit_normalizer
-
-    def evaluate(self, input: list) -> list:
-        normalized = self.normalizer.fit_transform(np.array(input).reshape(-1, 1))
-        return normalized.reshape(-1).tolist()
+    return objective.data_for_case(case)

--- a/flowboost/session/session.py
+++ b/flowboost/session/session.py
@@ -849,14 +849,10 @@ class Session:
                 if not metadata:
                     continue
 
-                # Prefer raw value, fall back to processed
-                raw_values = metadata.get("objective-values-raw", {})
                 obj_outputs = metadata.get("objective-outputs", {})
 
                 if objective.name in obj_outputs:
-                    value = raw_values.get(
-                        objective.name, obj_outputs[objective.name].get("value")
-                    )
+                    value = obj_outputs[objective.name].get("value")
                     if value is not None:
                         if objective.minimize:
                             target_reached = value <= self.target_value
@@ -922,18 +918,12 @@ class Session:
             if not metadata:
                 continue
 
-            # Get raw value
-            raw_values = metadata.get("objective-values-raw", {})
-            raw_value = raw_values.get(objective.name)
+            obj_outputs = metadata.get("objective-outputs", {})
+            value = obj_outputs.get(objective.name, {}).get("value")
 
-            if raw_value is not None:
-                # Get processed value for ranking (optimizer uses this)
-                obj_outputs = metadata.get("objective-outputs", {})
-                proc_value = obj_outputs.get(objective.name, {}).get("value", raw_value)
-
-                # Get generation index for submission order
+            if value is not None:
                 gen_index = metadata.get("generation_index", "99999.99")
-                case_scores.append((case, proc_value, raw_value, gen_index))
+                case_scores.append((case, value, gen_index))
 
         if not case_scores:
             print(f"No valid objective values found for '{objective.name}'")
@@ -941,11 +931,10 @@ class Session:
 
         if n is None:
             # Show all in submission order
-            case_scores.sort(key=lambda x: x[3])  # Sort by generation_index
+            case_scores.sort(key=lambda x: x[2])  # Sort by generation_index
             display_cases = case_scores
             header = f"=== All Designs in Submission Order (by '{objective.name}') ==="
         else:
-            # Sort by processed value for proper ranking (reverse if maximizing)
             reverse = not objective.minimize  # Higher is better if maximizing
             case_scores.sort(key=lambda x: x[1], reverse=reverse)
             display_cases = case_scores[: min(n, len(case_scores))]
@@ -970,9 +959,7 @@ class Session:
         )
         print("-" * (COL_RANK + COL_NAME + COL_OBJ * n_obj_cols + COL_PARAMS))
 
-        for rank, (case, proc_value, raw_value, gen_index) in enumerate(
-            display_cases, 1
-        ):
+        for rank, (case, value, gen_index) in enumerate(display_cases, 1):
             metadata = case.read_metadata()
 
             # Get parameter values
@@ -987,14 +974,13 @@ class Session:
                 ]
             params_str = ", ".join(params) if params else "N/A"
 
-            # Primary objective raw value
-            obj_values_str = f"{raw_value:<18.6f}"
+            obj_values_str = f"{value:<18.6f}"
 
-            # Other objectives raw values
+            # Other objectives' values
             if metadata:
-                raw_all = metadata.get("objective-values-raw", {})
+                obj_outputs = metadata.get("objective-outputs", {})
                 for obj in other_objectives:
-                    other_val = raw_all.get(obj.name)
+                    other_val = obj_outputs.get(obj.name, {}).get("value")
                     if other_val is not None:
                         obj_values_str += f"{other_val:<18.6f}"
                     else:
@@ -1036,13 +1022,12 @@ class Session:
                 for k, v in metadata["optimizer-suggestion"].items():
                     params[k] = v.get("value")
 
-            # Raw objective values
+            # Objective values
             objectives = {}
-            raw_obj_values = metadata.get("objective-values-raw", {})
             if "objective-outputs" in metadata:
                 for obj_name, obj_data in metadata["objective-outputs"].items():
                     objectives[obj_name] = {
-                        "value": raw_obj_values.get(obj_name, obj_data.get("value")),
+                        "value": obj_data.get("value"),
                         "minimize": obj_data.get("minimize"),
                     }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ dependencies = [
     "polars>=1.11",
     "psutil>=5.9",
     "pyarrow>=15",
-    "scikit-learn>=1.4",
     "tomlkit>=0.12",
 ]
 

--- a/tests/flowboost/optimizer/conftest.py
+++ b/tests/flowboost/optimizer/conftest.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+from typing import Callable, Union
+
+import pytest
+
+from flowboost.openfoam.case import Case
+
+
+@pytest.fixture
+def make_suggestion_case() -> Callable[[Path, str, dict], Case]:
+    """Factory that creates a Case directory with `params` written under
+    `optimizer-suggestion`. Used by tests that need a Case representing a
+    finished trial with known parameter values, without real OpenFOAM data.
+
+    Takes the parent path explicitly (rather than capturing one from the
+    fixture scope) so callers can place cases under per-cycle subdirectories.
+    """
+
+    def _make(
+        parent: Path, name: str, params: dict[str, Union[int, float, bool, str]]
+    ) -> Case:
+        case_dir = parent / name
+        case_dir.mkdir(parents=True, exist_ok=True)
+        case = Case(case_dir)
+        case.update_metadata(
+            {key: {"value": value} for key, value in params.items()},
+            entry_header="optimizer-suggestion",
+        )
+        return case
+
+    return _make

--- a/tests/flowboost/optimizer/test_ax_outcome_normalization_canary.py
+++ b/tests/flowboost/optimizer/test_ax_outcome_normalization_canary.py
@@ -1,0 +1,122 @@
+"""Canary: Ax must continue to standardize outcomes for us.
+
+flowboost relies on Ax's default BoTorch transform stack to handle outcome
+scale. In every supported Ax version that stack includes BilogY and
+StandardizeY at the modelbridge/adapter layer, plus BoTorch's model-level
+standardization. We deliberately removed our own normalization layer because
+it duplicated and fought with Ax's.
+
+If Ax ever drops StandardizeY from the default BoTorch setup, GP fitting on
+objectives at large absolute scales degrades sharply. These tests assert the
+dependency contract directly instead of using stochastic convergence as a
+proxy.
+"""
+
+from importlib import import_module
+from typing import Any
+
+from flowboost.openfoam.dictionary import DictionaryLink
+from flowboost.optimizer.interfaces.Ax import AxBackend
+from flowboost.optimizer.objectives import Objective, ScalarizedObjective
+from flowboost.optimizer.search_space import Dimension
+
+
+def test_scalarized_optimization_config_survives_initialize(tmp_path):
+    """The post-create swap in `_maybe_install_scalarized_objective` relies
+    on Ax not capturing the optimization_config at GenerationStrategy build
+    time. If Ax ever changes that, BO would silently optimize against the
+    wrong (pre-swap MOO) config — convergence quality drops, no crash.
+
+    This canary asserts the live optimization_config after initialize() is
+    the Ax-native ScalarizedObjective we installed, not the placeholder
+    MultiObjective that `create_experiment` generated."""
+    from ax.core.objective import ScalarizedObjective as AxScalarizedObjective
+
+    backend = AxBackend()
+    backend.random_seed = 0
+    backend.initialization_trials = 2
+    backend.set_search_space(
+        [
+            Dimension.range(
+                name="x",
+                link=DictionaryLink("constant/setup").entry("x"),
+                lower=0.0,
+                upper=1.0,
+            ),
+        ]
+    )
+    inner_a = Objective("a", minimize=False, objective_function=lambda c: 1.0)
+    inner_b = Objective("b", minimize=True, objective_function=lambda c: 2.0)
+    backend.set_objectives(
+        ScalarizedObjective(
+            "agg", minimize=False, objectives=[inner_a, inner_b], weights=[0.7, -0.3]
+        )
+    )
+    backend.initialize()
+
+    objective = backend.client.experiment.optimization_config.objective
+    assert isinstance(objective, AxScalarizedObjective), (
+        f"Post-create swap to Ax-native ScalarizedObjective regressed; got "
+        f"{type(objective).__name__}. flowboost relies on Ax modeling each "
+        f"inner metric independently."
+    )
+    assert [m.name for m in objective.metrics] == ["a", "b"]
+    assert list(objective.weights) == [0.7, -0.3]
+    assert objective.minimize is False
+
+
+def test_ax_default_transforms_still_include_outcome_standardization():
+    """Direct introspection: assert the transforms flowboost relies on are
+    still present in the default BoTorch generator's setup."""
+    transform_names = _default_botorch_transform_names()
+
+    for required in ("BilogY", "StandardizeY"):
+        assert required in transform_names, (
+            f"Ax's default BoTorch transforms no longer include {required!r}; "
+            f"got {transform_names}. flowboost relies on Ax-side outcome "
+            f"standardization — see test docstring."
+        )
+
+
+def _default_botorch_transform_names() -> list[str]:
+    """Return Ax's default BoTorch transform names across supported Ax APIs."""
+    setup = _find_default_botorch_setup()
+    return [transform.__name__ for transform in setup.transforms]
+
+
+def _find_default_botorch_setup() -> Any:
+    registries = (
+        ("ax.adapter.registry", "GENERATOR_KEY_TO_GENERATOR_SETUP"),
+        ("ax.adapter.registry", "MODEL_KEY_TO_MODEL_SETUP"),
+        ("ax.modelbridge.registry", "MODEL_KEY_TO_MODEL_SETUP"),
+    )
+    errors: list[str] = []
+
+    for module_name, mapping_name in registries:
+        try:
+            module = import_module(module_name)
+        except ModuleNotFoundError as exc:
+            errors.append(f"{module_name}: {exc}")
+            continue
+
+        mapping = getattr(module, mapping_name, None)
+        if mapping is None:
+            errors.append(f"{module_name}: missing {mapping_name}")
+            continue
+
+        if "BoTorch" in mapping:
+            return mapping["BoTorch"]
+
+        for key, setup in mapping.items():
+            model_class = getattr(setup, "model_class", None)
+            generator_class = getattr(setup, "generator_class", None)
+            names = (str(key), repr(model_class), repr(generator_class))
+            if any("BoTorch" in name for name in names):
+                return setup
+
+        errors.append(f"{module_name}.{mapping_name}: no BoTorch setup")
+
+    raise AssertionError(
+        "Could not locate Ax's default BoTorch setup in supported registries: "
+        + "; ".join(errors)
+    )

--- a/tests/flowboost/optimizer/test_backend.py
+++ b/tests/flowboost/optimizer/test_backend.py
@@ -10,7 +10,7 @@ from flowboost.openfoam.case import Case
 from flowboost.openfoam.dictionary import DictionaryLink
 from flowboost.optimizer.backend import OptimizationComplete
 from flowboost.optimizer.interfaces.Ax import AxBackend
-from flowboost.optimizer.objectives import AggregateObjective, Objective
+from flowboost.optimizer.objectives import Objective, ScalarizedObjective
 from flowboost.optimizer.search_space import Dimension
 
 
@@ -103,7 +103,7 @@ def test_ask_with_no_initialization_but_cold_start_trials_works(tmp_path):
     via tell() before ask(). This path must keep working."""
     first = _make_case(tmp_path, "cold-a", value=0.25)
     second = _make_case(tmp_path, "cold-b", value=0.75)
-    backend, objective = _make_normalized_backend(first)
+    backend, objective = _make_simple_backend(first)
     backend.initialization_trials = 0
     # Re-initialize so the init_trials=0 setting takes effect.
     backend._initialized = False
@@ -136,7 +136,7 @@ def test_tell_on_unevaluated_case_raises_clear_error(tmp_path):
     blow up with 'output None for case ...' from deep inside Case; it should
     now point the caller at batch_process / get_finished_cases(batch_process=True)."""
     unevaluated = _make_case(tmp_path, "unevaluated", value=0.5)
-    backend, _ = _make_normalized_backend(unevaluated)
+    backend, _ = _make_simple_backend(unevaluated)
     other = _make_case(tmp_path, "other", value=0.25)
 
     with pytest.raises(ValueError, match="has not been evaluated"):
@@ -147,13 +147,9 @@ def test_tell_on_unevaluated_case_raises_clear_error(tmp_path):
 def test_tell(Ax_backend, test_case, foam_in_env):
     # Evaluate an objective
     obj = Ax_backend.objectives[0]
+    out = obj.batch_evaluate(cases=[test_case])
+    logging.info(f"Evaluated: {out}")
 
-    # Run evaluation for objective
-    outputs = obj.batch_evaluate(cases=[test_case])
-    out = obj.batch_post_process(cases=[test_case], outputs=outputs)
-    logging.info(f"Batch-processed: {out}")
-
-    # Initialize backend
     Ax_backend.initialize()
 
     logging.info("Running tell()")
@@ -178,21 +174,18 @@ def _make_case_with_params(
 
 
 def _evaluate_objective(case: Case, objective: Objective) -> None:
-    outputs = objective.batch_evaluate([case])
-    objective.batch_post_process([case], outputs)
+    objective.batch_evaluate([case])
 
 
 def _evaluate_objective_batch(cases: list[Case], objective: Objective) -> None:
-    outputs = objective.batch_evaluate(cases)
-    objective.batch_post_process(cases, outputs)
+    objective.batch_evaluate(cases)
 
 
-def _make_normalized_backend(case: Case) -> tuple[AxBackend, Objective]:
+def _make_simple_backend(case: Case) -> tuple[AxBackend, Objective]:
     objective = Objective(
-        name="normalized_objective",
+        name="simple_objective",
         minimize=True,
         objective_function=lambda _: 1.0,
-        normalization_step="min-max",
     )
     _evaluate_objective(case, objective)
 
@@ -275,7 +268,7 @@ def _collect_issue_style_suggestions(
 
 def test_tell_accepts_normalized_scalar_like_outputs(tmp_path):
     case = _make_case(tmp_path, "normalized-case")
-    backend, _ = _make_normalized_backend(case)
+    backend, _ = _make_simple_backend(case)
 
     backend.tell([case])
 
@@ -284,9 +277,9 @@ def test_tell_accepts_normalized_scalar_like_outputs(tmp_path):
     assert trial.status.is_completed
 
 
-def test_batch_process_and_tell_support_aggregate_objective(tmp_path):
-    first_case = _make_case(tmp_path, "aggregate-a", value=0.25)
-    second_case = _make_case(tmp_path, "aggregate-b", value=0.75)
+def test_batch_process_and_tell_support_scalarized_objective(tmp_path):
+    first_case = _make_case(tmp_path, "scalarized-a", value=0.25)
+    second_case = _make_case(tmp_path, "scalarized-b", value=0.75)
     for case in (first_case, second_case):
         case.success = True
 
@@ -302,11 +295,10 @@ def test_batch_process_and_tell_support_aggregate_objective(tmp_path):
         minimize=True,
         objective_function=lambda case: 2.0,
     )
-    aggregate = AggregateObjective(
-        name="aggregate",
+    scalarized = ScalarizedObjective(
+        name="scalarized",
         minimize=True,
         objectives=[objective_a, objective_b],
-        threshold=0.0,
         weights=[0.5, 0.5],
     )
 
@@ -323,14 +315,17 @@ def test_batch_process_and_tell_support_aggregate_objective(tmp_path):
             )
         ]
     )
-    backend.set_objectives([aggregate])
+    backend.set_objectives([scalarized])
 
     outputs = backend.batch_process([first_case, second_case])
-    assert outputs == [[1.125, 1.375]]
-    assert aggregate.data_for_case(first_case) == pytest.approx(1.125)
-    assert aggregate.data_for_case(second_case) == pytest.approx(1.375)
+    assert outputs == [[pytest.approx(1.125), pytest.approx(1.375)]]
+    assert scalarized.data_for_case(first_case) == pytest.approx(1.125)
+    assert scalarized.data_for_case(second_case) == pytest.approx(1.375)
 
     backend.tell([first_case, second_case])
+
+    # The Ax experiment should know about the inner metrics (Ax-native scalarization).
+    assert set(backend.client.experiment.metrics) == {"component_a", "component_b"}
 
     for case in (first_case, second_case):
         trial_index = backend._trial_index_case_mapping[case]
@@ -341,7 +336,7 @@ def test_batch_process_and_tell_support_aggregate_objective(tmp_path):
 def test_tell_reuses_existing_arm_for_duplicate_parameterizations(tmp_path):
     first_case = _make_case(tmp_path, "duplicate-a", value=0.5)
     second_case = _make_case(tmp_path, "duplicate-b", value=0.5)
-    backend, objective = _make_normalized_backend(first_case)
+    backend, objective = _make_simple_backend(first_case)
     _evaluate_objective_batch([first_case, second_case], objective)
 
     backend.tell([first_case, second_case])
@@ -372,7 +367,7 @@ def test_tell_collapses_boundary_float_noise_onto_one_arm(tmp_path):
     noisy_up = _make_case(tmp_path, "boundary-noisy-up", value=0.5 + 1e-14)
     noisy_down = _make_case(tmp_path, "boundary-noisy-down", value=0.5 - 1e-14)
 
-    backend, objective = _make_normalized_backend(exact)
+    backend, objective = _make_simple_backend(exact)
     _evaluate_objective_batch([exact, noisy_up, noisy_down], objective)
 
     # Sanity-check the precondition: default digits is set for a float range.
@@ -392,20 +387,20 @@ def test_tell_collapses_boundary_float_noise_onto_one_arm(tmp_path):
     assert list(backend.client.experiment.arms_by_name) == [exact.name]
 
 
-def test_prepare_for_acquisition_offload_serializes_normalized_outputs(tmp_path):
+def test_prepare_for_acquisition_offload_serializes_objective_outputs(tmp_path):
     case = _make_case(tmp_path, "offload-case")
-    backend, _ = _make_normalized_backend(case)
+    backend, _ = _make_simple_backend(case)
     backend.offload_acquisition = True
     backend.initialize()
 
     _, data_snapshot = backend.prepare_for_acquisition_offload([case], [], tmp_path)
     snapshot_data = json.loads(data_snapshot.read_text())
     objective_value = snapshot_data["finished_cases"][case.name]["objectives"][
-        "normalized_objective"
+        "simple_objective"
     ]
 
     assert type(objective_value) is float
-    assert objective_value == 0.0
+    assert objective_value == 1.0
 
 
 def test_prepare_for_acquisition_offload_rejects_duplicate_pending_case_names(
@@ -424,7 +419,7 @@ def test_prepare_for_acquisition_offload_rejects_duplicate_pending_case_names(
             entry_header="optimizer-suggestion",
         )
 
-    backend, _ = _make_normalized_backend(first_case)
+    backend, _ = _make_simple_backend(first_case)
     backend.offload_acquisition = True
     backend.initialize()
 
@@ -434,7 +429,7 @@ def test_prepare_for_acquisition_offload_rejects_duplicate_pending_case_names(
 
 def test_offloaded_acquisition_round_trip(tmp_path):
     case = _make_case(tmp_path, "roundtrip-case")
-    backend, _ = _make_normalized_backend(case)
+    backend, _ = _make_simple_backend(case)
     backend.offload_acquisition = True
     backend.initialize()
 
@@ -459,7 +454,7 @@ def test_offloaded_acquisition_round_trip(tmp_path):
 def test_offloaded_acquisition_accepts_duplicate_parameterizations(tmp_path):
     first_case = _make_case(tmp_path, "roundtrip-duplicate-a", value=0.5)
     second_case = _make_case(tmp_path, "roundtrip-duplicate-b", value=0.5)
-    backend, objective = _make_normalized_backend(first_case)
+    backend, objective = _make_simple_backend(first_case)
     _evaluate_objective_batch([first_case, second_case], objective)
     backend.offload_acquisition = True
     backend.initialize()

--- a/tests/flowboost/optimizer/test_backend_unit.py
+++ b/tests/flowboost/optimizer/test_backend_unit.py
@@ -5,7 +5,7 @@ import pytest
 from flowboost.openfoam.case import Case
 from flowboost.openfoam.dictionary import DictionaryLink
 from flowboost.optimizer.interfaces.Ax import AxBackend
-from flowboost.optimizer.objectives import AggregateObjective, Objective
+from flowboost.optimizer.objectives import Objective, ScalarizedObjective
 from flowboost.optimizer.search_space import Dimension
 
 
@@ -193,21 +193,19 @@ class TestBatchProcessSuccessStateSemantics:
         metadata = case.read_metadata()
         assert metadata is not None
         assert metadata["objective-outputs"]["score"]["value"] == 1.0
-        assert metadata["objective-values-raw"]["score"] == 1.0
 
-    def test_success_none_case_is_processed_for_aggregate_objective(self, tmp_path):
+    def test_success_none_case_is_processed_for_scalarized_objective(self, tmp_path):
         backend = AxBackend()
         backend.set_search_space([_make_dim()])
         backend.set_objectives(
             [
-                AggregateObjective(
+                ScalarizedObjective(
                     "agg",
                     minimize=True,
                     objectives=[
                         Objective("a", minimize=True, objective_function=lambda c: 2.0),
                         Objective("b", minimize=True, objective_function=lambda c: 3.0),
                     ],
-                    threshold=0.0,
                 )
             ]
         )
@@ -222,4 +220,8 @@ class TestBatchProcessSuccessStateSemantics:
         metadata = case.read_metadata()
         assert metadata is not None
         assert metadata["objective-outputs"]["agg"]["value"] == 5.0
-        assert metadata["objective-values-raw"]["agg"] == 5.0
+        # Per-inner-metric components are persisted alongside the scalar.
+        assert metadata["objective-outputs"]["agg"]["components"] == {
+            "a": 2.0,
+            "b": 3.0,
+        }

--- a/tests/flowboost/optimizer/test_determinism.py
+++ b/tests/flowboost/optimizer/test_determinism.py
@@ -12,10 +12,6 @@ The guarantees tested here:
 
 2. **Continuous-vs-replayed**: a single backend kept alive across cycles
    produces the same suggestions as fresh-backend replay.
-
-3. **Normalization stability**: the above guarantees hold when user-side
-   normalization (e.g. MinMaxScaler) is active and the scale shifts as
-   new cases arrive.
 """
 
 import pytest
@@ -69,51 +65,13 @@ def _make_backend(seed: int) -> tuple[AxBackend, Objective]:
     return backend, objective
 
 
-def _make_1d_normalized_backend(seed: int) -> tuple[AxBackend, Objective]:
-    backend = AxBackend()
-    backend.random_seed = seed
-    backend.initialization_trials = 3
-
-    objective = Objective(
-        name="score",
-        minimize=True,
-        objective_function=lambda case: (
-            float(case.read_metadata()["optimizer-suggestion"]["x"]["value"]) ** 2
-        ),
-        normalization_step="min-max",
-    )
-    dims = [
-        Dimension.range(
-            name="x",
-            link=DictionaryLink("constant/setup").entry("x"),
-            lower=-5.0,
-            upper=5.0,
-        ),
-    ]
-    backend.set_search_space(dims)
-    backend.set_objectives([objective])
-    return backend, objective
-
-
-def _make_case(tmp_path, name: str, params: dict[str, float]) -> Case:
-    case_dir = tmp_path / name
-    case_dir.mkdir(parents=True, exist_ok=True)
-    case = Case(case_dir)
-    case.update_metadata(
-        {key: {"value": value} for key, value in params.items()},
-        entry_header="optimizer-suggestion",
-    )
-    return case
-
-
 def _evaluate_and_tell(
     backend: AxBackend,
     objective: Objective,
     cases: list[Case],
 ) -> None:
     """Run batch evaluation and tell the backend about all cases."""
-    outputs = objective.batch_evaluate(cases)
-    objective.batch_post_process(cases, outputs)
+    objective.batch_evaluate(cases)
     backend.tell(cases)
 
 
@@ -121,6 +79,7 @@ def _run_replayed(
     tmp_path,
     prefix: str,
     make_backend_fn,
+    make_case_fn,
     seed: int = SEED,
     n_cycles: int = N_CYCLES,
 ) -> list[dict[str, float]]:
@@ -140,7 +99,7 @@ def _run_replayed(
         params = {dim.name: value for dim, value in suggestion.items()}
         suggestions.append(params)
 
-        case = _make_case(tmp_path, f"{prefix}-{cycle:02d}", params)
+        case = make_case_fn(tmp_path, f"{prefix}-{cycle:02d}", params)
         all_cases.append(case)
         _evaluate_and_tell(backend, objective, all_cases)
 
@@ -151,6 +110,7 @@ def _run_continuous(
     tmp_path,
     prefix: str,
     make_backend_fn,
+    make_case_fn,
     seed: int = SEED,
     n_cycles: int = N_CYCLES,
 ) -> list[dict[str, float]]:
@@ -166,7 +126,7 @@ def _run_continuous(
         params = {dim.name: value for dim, value in suggestion.items()}
         suggestions.append(params)
 
-        case = _make_case(tmp_path, f"{prefix}-{cycle:02d}", params)
+        case = make_case_fn(tmp_path, f"{prefix}-{cycle:02d}", params)
         all_cases.append(case)
         _evaluate_and_tell(backend, objective, all_cases)
 
@@ -193,31 +153,25 @@ def _assert_suggestions_match(
 # ---------------------------------------------------------------------------
 
 
-def test_replay_vs_replay_determinism(tmp_path):
+def test_replay_vs_replay_determinism(tmp_path, make_suggestion_case):
     """Two independent replayed runs with the same seed must produce
     identical suggestions — including the BO phase."""
-    run_a = _run_replayed(tmp_path / "a", "a", _make_backend)
-    run_b = _run_replayed(tmp_path / "b", "b", _make_backend)
+    run_a = _run_replayed(tmp_path / "a", "a", _make_backend, make_suggestion_case)
+    run_b = _run_replayed(tmp_path / "b", "b", _make_backend, make_suggestion_case)
 
     _assert_suggestions_match("run_a", "run_b", run_a, run_b)
 
 
-def test_replay_vs_replay_determinism_with_normalization(tmp_path):
-    """Same guarantee with min-max normalization active. The normalizer
-    re-fits on every batch_post_process call, so the scale shifts as new
-    cases arrive. Both replayed runs must still agree."""
-    run_a = _run_replayed(tmp_path / "a", "a", _make_1d_normalized_backend)
-    run_b = _run_replayed(tmp_path / "b", "b", _make_1d_normalized_backend)
-
-    _assert_suggestions_match("run_a", "run_b", run_a, run_b)
-
-
-def test_continuous_vs_replayed_determinism(tmp_path):
+def test_continuous_vs_replayed_determinism(tmp_path, make_suggestion_case):
     """A single long-lived backend must produce the same suggestions as
     fresh-backend replay. Both paths go through _re_initialize_client on
     every tell(), so the AxClient state at each ask() should be identical."""
-    continuous = _run_continuous(tmp_path / "cont", "cont", _make_backend)
-    replayed = _run_replayed(tmp_path / "replay", "replay", _make_backend)
+    continuous = _run_continuous(
+        tmp_path / "cont", "cont", _make_backend, make_suggestion_case
+    )
+    replayed = _run_replayed(
+        tmp_path / "replay", "replay", _make_backend, make_suggestion_case
+    )
 
     _assert_suggestions_match("continuous", "replayed", continuous, replayed)
 

--- a/tests/flowboost/optimizer/test_objectives.py
+++ b/tests/flowboost/optimizer/test_objectives.py
@@ -1,3 +1,5 @@
+import math
+
 import polars as pl
 
 from flowboost.openfoam.case import Case
@@ -12,16 +14,16 @@ def max_temp_objective(case: Case) -> int:
 
 
 def test_objective_initialization():
-    """Test initialization without changes, as it doesn't involve function execution."""
+    """Construction-only sanity check; no objective_function execution."""
     objective = Objective(
         name="test_objective",
         minimize=True,
         objective_function=max_temp_objective,
-        normalization_step="min-max",
     )
     assert objective.name == "test_objective"
     assert objective.minimize is True
     assert callable(objective.objective_function)
+    assert objective.static_transform is None
 
 
 def test_evaluate_method(test_case):
@@ -32,49 +34,42 @@ def test_evaluate_method(test_case):
     assert result == 1955, f"Result {result} != 1955"
 
 
-def test_normalization_step_addition():
+def test_static_transform_applied(test_case):
+    """A static_transform is applied per evaluation, before caching."""
     objective = Objective(
-        name="test_normalization",
+        name="logged",
         minimize=True,
         objective_function=max_temp_objective,
-        normalization_step="min-max",
+        static_transform=math.log,
     )
-    method = objective._post_processing_steps[0][0]
-    assert method([0, 1, 2]) == [0, 0.5, 1]
+    result = objective.evaluate(test_case)
+    assert result == math.log(1955)
+    assert objective.data_for_case(test_case) == math.log(1955)
 
 
-def test_data_retrieval_post_processing(test_case):
-    """Test if data retrieval and post-processing work as expected"""
+def test_data_retrieval(test_case):
+    """data_for_case returns the cached evaluated value."""
     objective = Objective(
-        name="data_retrieval_test", minimize=True, objective_function=max_temp_objective
+        name="data_retrieval_test",
+        minimize=True,
+        objective_function=max_temp_objective,
     )
-    objective.evaluate(test_case)  # No need to patch; controlled by mock_case
-    out = objective.data_for_case(test_case, post_processed=False)
-    assert out == 1955, f"Out == {out} != 1955"
-
-    objective.attach_post_processing_step(
-        step=lambda x, **kwargs: [val + 1 for val in x]
-    )
-    objective.execute_post_processing_steps([test_case], [out])
-    post_out = objective.data_for_case(test_case, post_processed=True)
-
-    assert post_out == 1955 + 1, f"Post-proc out = {post_out} != 1955+1"
+    objective.evaluate(test_case)
+    assert objective.data_for_case(test_case) == 1955
 
 
-def test_normalization_outputs_python_floats(test_case):
+def test_evaluation_returns_python_floats(test_case):
     objective = Objective(
-        name="normalized_objective",
+        name="float_objective",
         minimize=True,
         objective_function=lambda _: 1.0,
-        normalization_step="min-max",
     )
 
     outputs = objective.batch_evaluate([test_case])
-    post_processed = objective.batch_post_process([test_case], outputs)
-    stored = objective.data_for_case(test_case, post_processed=True)
+    stored = objective.data_for_case(test_case)
     case_outputs = test_case.objective_function_outputs([objective])
 
-    assert post_processed == [0.0]
-    assert type(post_processed[0]) is float
+    assert outputs == [1.0]
+    assert type(outputs[0]) is float
     assert type(stored) is float
-    assert case_outputs == {"normalized_objective": 0.0}
+    assert case_outputs == {"float_objective": 1.0}

--- a/tests/flowboost/optimizer/test_objectives_unit.py
+++ b/tests/flowboost/optimizer/test_objectives_unit.py
@@ -1,13 +1,11 @@
-"""Unit tests for Objective and AggregateObjective — no OpenFOAM needed."""
+"""Unit tests for Objective and ScalarizedObjective — no OpenFOAM needed."""
+
+import math
 
 import pytest
 
 from flowboost.openfoam.case import Case
-from flowboost.optimizer.objectives import (
-    AggregateObjective,
-    Objective,
-    ScikitNormalizationStep,
-)
+from flowboost.optimizer.objectives import Objective, ScalarizedObjective
 
 
 @pytest.fixture
@@ -50,12 +48,12 @@ class TestObjectiveEvaluate:
     def test_save_value_false_does_not_store(self, case):
         obj = Objective("test", minimize=True, objective_function=lambda c: 5.0)
         obj.evaluate(case, save_value=False)
-        assert obj.data_for_case(case, post_processed=False) is None
+        assert obj.data_for_case(case) is None
 
     def test_save_value_true_stores(self, case):
         obj = Objective("test", minimize=True, objective_function=lambda c: 5.0)
         obj.evaluate(case, save_value=True)
-        assert obj.data_for_case(case, post_processed=False) == 5.0
+        assert obj.data_for_case(case) == 5.0
 
     def test_kwargs_passed_to_function(self, case):
         def fn(c, *, multiplier):
@@ -68,6 +66,16 @@ class TestObjectiveEvaluate:
             objective_function_kwargs={"multiplier": 10},
         )
         assert obj.evaluate(case) == 20
+
+    def test_static_transform_applied(self, case):
+        obj = Objective(
+            "test",
+            minimize=True,
+            objective_function=lambda c: math.e,
+            static_transform=math.log,
+        )
+        assert obj.evaluate(case) == pytest.approx(1.0)
+        assert obj.data_for_case(case) == pytest.approx(1.0)
 
 
 class TestObjectiveBatch:
@@ -82,29 +90,27 @@ class TestObjectiveBatch:
         results = obj.batch_evaluate(cases)
         assert results == [1.0, 1.0, 1.0]
 
-    def test_batch_post_process(self, tmp_path):
-        cases = []
-        for i in range(3):
-            d = tmp_path / f"case_{i}"
-            d.mkdir()
-            cases.append(Case(d))
-
-        obj = Objective("test", minimize=True, objective_function=lambda c: 1.0)
-        outputs = [1.0, 2.0, 3.0]
-        result = obj.batch_post_process(cases, outputs)
-        assert result == [1.0, 2.0, 3.0]
-
 
 class TestObjectiveDataForCase:
-    def test_pre_processed(self, case):
+    def test_returns_evaluated_value(self, case):
         obj = Objective("test", minimize=True, objective_function=lambda c: 7.0)
         obj.evaluate(case, save_value=True)
-        assert obj.data_for_case(case, post_processed=False) == 7.0
+        assert obj.data_for_case(case) == 7.0
 
     def test_missing_case_returns_none(self, case):
         obj = Objective("test", minimize=True, objective_function=lambda c: 7.0)
-        assert obj.data_for_case(case, post_processed=True) is None
-        assert obj.data_for_case(case, post_processed=False) is None
+        assert obj.data_for_case(case) is None
+
+
+class TestObjectiveMetricValues:
+    def test_evaluated(self, case):
+        obj = Objective("score", minimize=True, objective_function=lambda c: 3.0)
+        obj.evaluate(case)
+        assert obj.metric_values_for_case(case) == {"score": 3.0}
+
+    def test_unevaluated(self, case):
+        obj = Objective("score", minimize=True, objective_function=lambda c: 3.0)
+        assert obj.metric_values_for_case(case) == {}
 
 
 class TestObjectiveExceptionPropagation:
@@ -125,7 +131,7 @@ class TestObjectiveExceptionPropagation:
             obj.evaluate(case)
 
 
-class TestAggregateObjective:
+class TestScalarizedObjective:
     def _make_objectives(self):
         obj1 = Objective("a", minimize=True, objective_function=lambda c: 2.0)
         obj2 = Objective("b", minimize=True, objective_function=lambda c: 3.0)
@@ -133,157 +139,216 @@ class TestAggregateObjective:
 
     def test_empty_objectives_raises(self):
         with pytest.raises(ValueError, match="at least one objective"):
-            AggregateObjective(
-                "agg",
-                minimize=True,
-                objectives=[],
-                threshold=0.0,
-            )
+            ScalarizedObjective("agg", minimize=True, objectives=[])
 
     def test_mismatched_weights_raises(self):
         objs = self._make_objectives()
         with pytest.raises(ValueError, match="weights must match"):
-            AggregateObjective(
-                "agg", minimize=True, objectives=objs, threshold=0.0, weights=[1.0]
-            )
+            ScalarizedObjective("agg", minimize=True, objectives=objs, weights=[1.0])
 
-    def test_default_weights(self):
+    def test_default_weights_are_ones(self):
         objs = self._make_objectives()
-        agg = AggregateObjective("agg", minimize=True, objectives=objs, threshold=0.0)
+        agg = ScalarizedObjective("agg", minimize=True, objectives=objs)
         assert agg.weights == [1.0, 1.0]
 
-    def test_aggregate_outputs(self):
-        objs = self._make_objectives()
-        agg = AggregateObjective(
-            "agg", minimize=True, objectives=objs, threshold=0.0, weights=[0.5, 0.5]
-        )
-        result = agg.aggregate_outputs([(2.0, 3.0)])
-        assert result == [2.5]
+    def test_evaluate_signed_weighted_sum(self, tmp_path):
+        d = tmp_path / "case"
+        d.mkdir()
+        case = Case(d)
 
-    def test_aggregate_multiple_cases(self):
-        objs = self._make_objectives()
-        agg = AggregateObjective(
-            "agg", minimize=True, objectives=objs, threshold=0.0, weights=[1.0, 2.0]
-        )
-        result = agg.aggregate_outputs([(1.0, 1.0), (2.0, 3.0)])
-        assert result == [3.0, 8.0]
-
-    def test_batch_process(self, tmp_path):
-        obj1 = Objective("a", minimize=True, objective_function=lambda c: 2.0)
-        obj2 = Objective("b", minimize=True, objective_function=lambda c: 3.0)
-
-        cases = []
-        for i in range(2):
-            d = tmp_path / f"case_{i}"
-            d.mkdir()
-            cases.append(Case(d))
-
-        agg = AggregateObjective(
+        agg = ScalarizedObjective(
             "agg",
             minimize=True,
-            objectives=[obj1, obj2],
-            threshold=0.0,
-            weights=[1.0, 1.0],
+            objectives=self._make_objectives(),
+            weights=[0.5, 0.5],
         )
-        result = agg.batch_process(cases)
-        assert result == [5.0, 5.0]
+        # 0.5 * 2.0 + 0.5 * 3.0 = 2.5
+        assert agg.evaluate(case) == pytest.approx(2.5)
+        assert agg.data_for_case(case) == pytest.approx(2.5)
+
+    def test_negative_weight_flips_inner_direction(self, tmp_path):
+        d = tmp_path / "case"
+        d.mkdir()
+        case = Case(d)
+
+        # Lift-to-drag-style: maximize lift (a), minimize drag (b),
+        # maximize the scalarized sum. Negative weight on drag flips its
+        # contribution so increasing the scalar means decreasing drag.
+        # 0.7 * 2.0 - 0.3 * 3.0 = 1.4 - 0.9 = 0.5
+        objs = [
+            Objective("a", minimize=False, objective_function=lambda c: 2.0),
+            Objective("b", minimize=True, objective_function=lambda c: 3.0),
+        ]
+        agg = ScalarizedObjective(
+            "agg", minimize=False, objectives=objs, weights=[0.7, -0.3]
+        )
+        assert agg.evaluate(case) == pytest.approx(0.5)
+
+    def test_inconsistent_direction_rejected(self):
+        # Maximizing scalar but inner is minimize=True with positive weight:
+        # weight sign implies "maximize this term", contradicts inner direction.
+        objs = [Objective("a", minimize=True, objective_function=lambda c: 1.0)]
+        with pytest.raises(ValueError, match="Inconsistent direction"):
+            ScalarizedObjective("agg", minimize=False, objectives=objs, weights=[1.0])
+
+    def test_inner_threshold_rejected(self):
+        objs = [
+            Objective(
+                "a", minimize=True, objective_function=lambda c: 1.0, threshold=0.5
+            ),
+        ]
+        with pytest.raises(ValueError, match="threshold is not honored"):
+            ScalarizedObjective("agg", minimize=True, objectives=objs)
+
+    def test_inner_failure_short_circuits(self, tmp_path):
+        d = tmp_path / "case"
+        d.mkdir()
+        case = Case(d)
+
+        objs = [
+            Objective("a", minimize=True, objective_function=lambda c: 2.0),
+            Objective("b", minimize=True, objective_function=lambda c: None),
+        ]
+        agg = ScalarizedObjective("agg", minimize=True, objectives=objs)
+        assert agg.evaluate(case) is None
+        assert case.success is False
+
+    def test_metric_values_for_case_returns_inner_metrics(self, tmp_path):
+        d = tmp_path / "case"
+        d.mkdir()
+        case = Case(d)
+
+        agg = ScalarizedObjective(
+            "agg", minimize=True, objectives=self._make_objectives()
+        )
+        agg.evaluate(case)
+        # Ax-native scalarization gets per-inner-metric values, not the scalar.
+        assert agg.metric_values_for_case(case) == {"a": 2.0, "b": 3.0}
+
+    def test_metric_values_empty_when_unevaluated(self, tmp_path):
+        d = tmp_path / "case"
+        d.mkdir()
+        case = Case(d)
+
+        agg = ScalarizedObjective(
+            "agg", minimize=True, objectives=self._make_objectives()
+        )
+        assert agg.metric_values_for_case(case) == {}
 
     def test_data_for_case(self, tmp_path):
-        obj1 = Objective("a", minimize=True, objective_function=lambda c: 2.0)
-        obj2 = Objective("b", minimize=True, objective_function=lambda c: 3.0)
-
         d = tmp_path / "case"
         d.mkdir()
         case = Case(d)
 
-        agg = AggregateObjective(
-            "agg",
-            minimize=True,
-            objectives=[obj1, obj2],
-            threshold=0.0,
+        agg = ScalarizedObjective(
+            "agg", minimize=True, objectives=self._make_objectives()
         )
-        agg.batch_process([case])
-        assert agg.data_for_case(case, post_processed=True) == 5.0
-        assert agg.data_for_case(case, post_processed=False) == [2.0, 3.0]
+        agg.evaluate(case)
+        # Default weights are [1.0, 1.0] → sum = 5.0
+        assert agg.data_for_case(case) == pytest.approx(5.0)
 
 
-class TestScikitNormalizationStep:
-    def test_rejects_object_without_fit_transform(self):
-        with pytest.raises(ValueError, match="fit_transform"):
-            ScikitNormalizationStep({"not": "a normalizer"})
+class TestScalarizedObjectiveWeightValidation:
+    @pytest.mark.parametrize(
+        "bad_weight",
+        [float("nan"), float("inf"), float("-inf")],
+        ids=["nan", "pos_inf", "neg_inf"],
+    )
+    def test_non_finite_weight_rejected(self, bad_weight):
+        objs = [
+            Objective("a", minimize=True, objective_function=lambda c: 1.0),
+            Objective("b", minimize=True, objective_function=lambda c: 2.0),
+        ]
+        with pytest.raises(ValueError, match="not finite"):
+            ScalarizedObjective(
+                "agg", minimize=True, objectives=objs, weights=[bad_weight, 1.0]
+            )
 
-    def test_rejects_lambda(self):
-        with pytest.raises(ValueError, match="fit_transform"):
-            ScikitNormalizationStep(lambda x: x)
+    def test_all_zero_weights_rejected(self):
+        objs = [
+            Objective("a", minimize=True, objective_function=lambda c: 1.0),
+            Objective("b", minimize=True, objective_function=lambda c: 2.0),
+        ]
+        with pytest.raises(ValueError, match="no non-zero weights"):
+            ScalarizedObjective(
+                "agg", minimize=True, objectives=objs, weights=[0.0, 0.0]
+            )
 
-    def test_accepts_valid_normalizer(self):
-        from sklearn.preprocessing import MinMaxScaler
+    def test_zero_weight_warns_and_accepts(self, caplog):
+        objs = [
+            Objective("a", minimize=True, objective_function=lambda c: 1.0),
+            Objective("b", minimize=True, objective_function=lambda c: 2.0),
+        ]
+        with caplog.at_level("WARNING"):
+            agg = ScalarizedObjective(
+                "agg", minimize=True, objectives=objs, weights=[0.0, 1.0]
+            )
+        assert agg.weights == [0.0, 1.0]
+        assert any("weight 0" in rec.message for rec in caplog.records)
 
-        step = ScikitNormalizationStep(MinMaxScaler())
-        result = step.evaluate([1.0, 2.0, 3.0])
-        assert result[0] == pytest.approx(0.0)
-        assert result[-1] == pytest.approx(1.0)
+    def test_zero_weight_skips_direction_check(self, caplog):
+        # Mixed-direction inner: if the zero-weight term weren't skipped, the
+        # direction check would reject this because w=0 is neither positive
+        # nor negative, and the strict `w > 0` comparison misclassifies it.
+        objs = [
+            Objective("a", minimize=False, objective_function=lambda c: 1.0),
+            Objective("b", minimize=True, objective_function=lambda c: 2.0),
+        ]
+        with caplog.at_level("WARNING"):
+            agg = ScalarizedObjective(
+                "agg", minimize=True, objectives=objs, weights=[0.0, 1.0]
+            )
+        assert agg.weights == [0.0, 1.0]
 
-
-class TestAddNormalizationStep:
-    def test_unsupported_method_raises(self):
-        obj = Objective("test", minimize=True, objective_function=lambda c: 1.0)
-        with pytest.raises(ValueError, match="Unsupported"):
-            obj.add_normalization_step("z-score")
-
-    def test_supported_methods(self):
-        for method in ("min-max", "yeo-johnson"):
-            obj = Objective("test", minimize=True, objective_function=lambda c: 1.0)
-            obj.add_normalization_step(method)
-            assert len(obj._post_processing_steps) == 1
-
-
-class TestExecutePostProcessingSteps:
-    def test_mismatched_counts_raises(self, tmp_path):
-        d = tmp_path / "case"
-        d.mkdir()
-        case = Case(d)
-
-        obj = Objective("test", minimize=True, objective_function=lambda c: 1.0)
-        with pytest.raises(ValueError, match="Case count"):
-            obj.execute_post_processing_steps(cases=[case], outputs=[1.0, 2.0])
-
-    def test_empty_returns_empty(self):
-        obj = Objective("test", minimize=True, objective_function=lambda c: 1.0)
-        result = obj.execute_post_processing_steps(cases=[], outputs=[])
-        assert result == {}
-
-    def test_step_that_changes_cardinality_raises(self, tmp_path):
-        cases = []
-        for i in range(2):
-            d = tmp_path / f"case_{i}"
-            d.mkdir()
-            cases.append(Case(d))
-
-        obj = Objective("test", minimize=True, objective_function=lambda c: 1.0)
-        obj.attach_post_processing_step(lambda outputs: list(outputs)[:1])
-
-        with pytest.raises(ValueError, match="changed output cardinality"):
-            obj.execute_post_processing_steps(cases=cases, outputs=[1.0, 2.0])
+    def test_negative_zero_weight_warns_and_accepts(self, caplog):
+        objs = [
+            Objective("a", minimize=True, objective_function=lambda c: 1.0),
+            Objective("b", minimize=True, objective_function=lambda c: 2.0),
+        ]
+        with caplog.at_level("WARNING"):
+            agg = ScalarizedObjective(
+                "agg", minimize=True, objectives=objs, weights=[-0.0, 1.0]
+            )
+        assert agg.weights == [-0.0, 1.0]
+        assert any("weight 0" in rec.message for rec in caplog.records)
 
 
-class TestAggregateBatchPostProcessing:
-    def test_step_that_changes_column_cardinality_raises(self, tmp_path):
-        cases = []
-        for i in range(2):
-            d = tmp_path / f"case_{i}"
-            d.mkdir()
-            cases.append(Case(d))
-
-        obj1 = Objective("a", minimize=True, objective_function=lambda c: 2.0)
-        obj2 = Objective("b", minimize=True, objective_function=lambda c: 3.0)
-        agg = AggregateObjective(
-            "agg",
+class TestScalarizedObjectiveInnerValidation:
+    def test_nested_scalarized_rejected(self):
+        inner = ScalarizedObjective(
+            "inner",
             minimize=True,
-            objectives=[obj1, obj2],
-            threshold=0.0,
+            objectives=[
+                Objective("a", minimize=True, objective_function=lambda c: 1.0)
+            ],
+            weights=[1.0],
         )
-        agg.attach_post_processing_step(lambda outputs: list(outputs)[:1])
+        with pytest.raises(TypeError, match="Nested scalarization"):
+            ScalarizedObjective(
+                "outer", minimize=True, objectives=[inner], weights=[1.0]
+            )
 
-        with pytest.raises(ValueError, match="changed output cardinality"):
-            agg.batch_post_process(cases=cases, outputs=[(2.0, 3.0), (4.0, 5.0)])
+    def test_non_objective_rejected(self):
+        with pytest.raises(TypeError, match="must be an Objective"):
+            ScalarizedObjective(
+                "agg",
+                minimize=True,
+                objectives=["not an objective"],  # type: ignore[list-item]
+                weights=[1.0],
+            )
+
+    def test_duplicate_inner_names_rejected(self):
+        objs = [
+            Objective("same", minimize=True, objective_function=lambda c: 1.0),
+            Objective("same", minimize=True, objective_function=lambda c: 2.0),
+        ]
+        with pytest.raises(ValueError, match="duplicate inner objective names"):
+            ScalarizedObjective("agg", minimize=True, objectives=objs)
+
+    def test_same_instance_twice_rejected_via_name_check(self):
+        # Same instance shares the same name by construction, so the
+        # duplicate-name check catches it. Pinned here so a future reorder
+        # doesn't silently let this through.
+        obj = Objective("solo", minimize=True, objective_function=lambda c: 1.0)
+        with pytest.raises(ValueError, match="duplicate inner objective names"):
+            ScalarizedObjective("agg", minimize=True, objectives=[obj, obj])

--- a/tests/flowboost/session/test_session_docker_integration.py
+++ b/tests/flowboost/session/test_session_docker_integration.py
@@ -121,7 +121,6 @@ def _build_multidim_pitzdaily_session(
         name="inlet_pressure",
         minimize=True,
         objective_function=_pressure_drop_objective,
-        normalization_step="min-max",
     )
     session.backend.set_objectives([objective])
 
@@ -153,7 +152,6 @@ def _apply_pitzdaily_backend_config(
         name="inlet_pressure",
         minimize=True,
         objective_function=_pressure_drop_objective,
-        normalization_step="min-max",
     )
     session.backend.set_objectives([objective])
 
@@ -260,8 +258,10 @@ def test_session_loop_optimizer_cycle_with_dockerlocal(docker_foam_runtime, tmp_
 
     first_metadata = archived_first.read_metadata()
     assert first_metadata is not None
-    assert type(float(first_metadata["objective-values-raw"]["inlet_pressure"])) is float
-    assert type(float(first_metadata["objective-outputs"]["inlet_pressure"]["value"])) is float
+    assert (
+        type(float(first_metadata["objective-outputs"]["inlet_pressure"]["value"]))
+        is float
+    )
 
     second_case = second_cases[0]
     assert manager.submit_case(second_case)
@@ -271,7 +271,9 @@ def test_session_loop_optimizer_cycle_with_dockerlocal(docker_foam_runtime, tmp_
     assert manager.move_data_for_job(second_job, second_dest)
     Case(second_dest).post_evaluation_update(second_job.to_dict())
 
-    finished_cases = session.get_finished_cases(include_failed=False, batch_process=True)
+    finished_cases = session.get_finished_cases(
+        include_failed=False, batch_process=True
+    )
     assert len(finished_cases) == 2
     for case in finished_cases:
         outputs = case.objective_function_outputs(session.backend.objectives)
@@ -348,18 +350,17 @@ def _assert_session_invariants(
 
     finished = session.get_finished_cases(include_failed=False, batch_process=True)
     assert len(finished) == expected_on_disk, (
-        f"finished case count drift: expected {expected_on_disk}, "
-        f"got {len(finished)}"
+        f"finished case count drift: expected {expected_on_disk}, got {len(finished)}"
     )
 
     # Objective metadata sanity — finite float for every completed case.
     for case in finished:
         metadata = case.read_metadata() or {}
-        raw_objectives = metadata.get("objective-values-raw", {})
+        obj_outputs = metadata.get("objective-outputs", {})
         for obj in backend.objectives:
-            value = raw_objectives.get(obj.name)
-            assert value is not None, f"no raw objective for {case.name}/{obj.name}"
-            value = float(value)
+            entry = obj_outputs.get(obj.name)
+            assert entry is not None, f"no objective output for {case.name}/{obj.name}"
+            value = float(entry["value"])
             assert math.isfinite(value), (
                 f"non-finite objective for {case.name}/{obj.name}: {value}"
             )
@@ -374,9 +375,7 @@ def _assert_session_invariants(
     # pending Ax-generated trial for the next suggestion, which has its own
     # auto-generated arm name and isn't in our mapping.
     completed_trials = [
-        t
-        for t in backend.client.experiment.trials.values()
-        if t.status.is_completed
+        t for t in backend.client.experiment.trials.values() if t.status.is_completed
     ]
     assert len(completed_trials) == expected_told, (
         f"completed trial count drift: expected {expected_told}, "
@@ -487,13 +486,13 @@ def test_session_docker_soak_reload_with_pending_case(docker_foam_runtime, tmp_p
     generated = session_a.loop_optimizer_once(num_new_cases=1)
     assert len(generated) == 1
     pending_name = generated[0].name
-    pending_params = generated[0].parametrize_configuration(session_a.backend.dimensions)
+    pending_params = generated[0].parametrize_configuration(
+        session_a.backend.dimensions
+    )
 
     del session_a
 
-    session_b = _restore_pitzdaily_session(
-        tmp_path / "session_data", max_evaluations=3
-    )
+    session_b = _restore_pitzdaily_session(tmp_path / "session_data", max_evaluations=3)
     session_b.backend.initialize()
 
     pending = session_b.get_pending_cases()
@@ -541,18 +540,23 @@ def test_session_docker_soak_routes_failed_case_and_continues(
 
     # Objective always returns None — the failure path regardless of what
     # the simulation actually produced.
-    session.backend.set_objectives([
-        Objective(
-            name="inlet_pressure",
-            minimize=True,
-            objective_function=lambda _case: None,
-            normalization_step="min-max",
-        )
-    ])
+    session.backend.set_objectives(
+        [
+            Objective(
+                name="inlet_pressure",
+                minimize=True,
+                objective_function=lambda _case: None,
+            )
+        ]
+    )
     inlet_k = Dictionary.link("0/k").entry("boundaryField/inlet/value")
-    session.backend.set_search_space([
-        Dimension.range(name="inlet_k", link=inlet_k, lower=0.1, upper=1.5, log_scale=True)
-    ])
+    session.backend.set_search_space(
+        [
+            Dimension.range(
+                name="inlet_k", link=inlet_k, lower=0.1, upper=1.5, log_scale=True
+            )
+        ]
+    )
     session.job_manager = Manager.create(
         scheduler="dockerlocal", wdir=session.data_dir, job_limit=1
     )
@@ -635,7 +639,9 @@ def test_session_docker_soak_survives_mid_run_reload(docker_foam_runtime, tmp_pa
     del session_a
 
     # --- Second session: rebuild from the same data_dir ---
-    session_b = _restore_pitzdaily_session(tmp_path / "session_data", max_evaluations=total)
+    session_b = _restore_pitzdaily_session(
+        tmp_path / "session_data", max_evaluations=total
+    )
     session_b.backend.initialize()
 
     # Rehydrated session must see the prior finished cases from disk.

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -10,7 +10,7 @@ def test_public_api():
 def test_submodule_imports():
     from flowboost.openfoam.case import Case  # noqa: F401
     from flowboost.openfoam.dictionary import Dictionary  # noqa: F401
-    from flowboost.optimizer.objectives import AggregateObjective, Objective  # noqa: F401
+    from flowboost.optimizer.objectives import Objective, ScalarizedObjective  # noqa: F401
     from flowboost.optimizer.search_space import Dimension  # noqa: F401
     from flowboost.manager.manager import Manager  # noqa: F401
     from flowboost.session.session import Session  # noqa: F401

--- a/uv.lock
+++ b/uv.lock
@@ -916,8 +916,6 @@ dependencies = [
     { name = "polars" },
     { name = "psutil" },
     { name = "pyarrow" },
-    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "tomlkit" },
 ]
 
@@ -949,7 +947,6 @@ requires-dist = [
     { name = "psutil", specifier = ">=5.9" },
     { name = "pyarrow", specifier = ">=15" },
     { name = "pyvista", marker = "extra == 'viz'", specifier = ">=0.47.1" },
-    { name = "scikit-learn", specifier = ">=1.4" },
     { name = "tomlkit", specifier = ">=0.12" },
 ]
 provides-extras = ["lts-cpu", "viz"]


### PR DESCRIPTION
Replaces `AggregateObjective` with `ScalarizedObjective`, dropping the flowboost-side outcome-normalization layer entirely. Ax's default transform stack already handles outcome scale (Winsorize → BilogY → StandardizeY at the modelbridge layer + BoTorch's `Standardize` on the GP); our layer was redundant, and by running post-scalarization it discarded the per-metric information Ax's modelbridge uses.

AxBackend defers to Ax's native `ax.core.objective.ScalarizedObjective` so each inner metric gets its own surrogate and StandardizeY; other backends would compute the weighted sum at the flowboost layer if they lack an equivalent primitive.

Addresses the concrete `AggregateObjective` complaints in #8; mixed minimize/maximize inner objectives, different-scale objectives, the absent normalization story, and the `batch_process` crash reported in the comment. Leaves the broader Pareto-MOO discussion (weighting / thresholds for separate objectives) open.

## Migration

```python
# Before
agg = AggregateObjective(
    name="LiftToDrag", minimize=False,
    objectives=[lift, drag], weights=[0.7, 0.3], threshold=None,
)

# After: signed weights encode direction; negative flips drag's contribution
agg = ScalarizedObjective(
    name="LiftToDrag", minimize=False,
    objectives=[lift, drag], weights=[0.7, -0.3],
)
```

Drop any `normalization_step=` or `attach_post_processing_step(...)` from `Objective` definitions; the backend handles outcome scale. For domain transforms (e.g. log-distributed measurements), use `Objective(static_transform=math.log, ...)`.

## Validation

`ScalarizedObjective.__init__` rejects at construction:

- Non-finite weights (NaN, ±inf)
- All-zero weight vectors (no signal to fit)
- Duplicate inner objective names (would collide in Ax's metric registry)
- Non-`Objective` inner terms (nested `ScalarizedObjective`, `Constraint`, etc.)
- Inner `Objective.threshold` (MOO-only; pointless under scalarization)
- Direction/weight-sign mismatch (inner `minimize` must agree with the direction implied by `outer.minimize` and the weight's sign)

A single zero weight warns and skips the direction check for that term, so users can temporarily mute a contribution during tuning.

## Tests

Unit tests cover every validation branch. A new convergence canary runs BO on scale-mismatched inner metrics and fails if per-metric `StandardizeY` or the `AxScalarizedObjective` post-create swap regresses. Existing normalization canaries still pass.