### PR TITLE
Add Constraint primitive; replace set_outcome_constraints string DSL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -226,3 +226,7 @@ __marimo__/
 
 # Streamlit
 .streamlit/secrets.toml
+
+# Figures
+*.png
+*.gif

--- a/examples/aerofoilNACA0012Steady/aerofoilNACA0012Steady.py
+++ b/examples/aerofoilNACA0012Steady/aerofoilNACA0012Steady.py
@@ -12,95 +12,105 @@ from pathlib import Path
 import coloredlogs
 import polars as pl
 
-from flowboost import Case, Dictionary, Dimension, Manager, Objective, Session
+from flowboost import (
+    Case,
+    Constraint,
+    Dictionary,
+    Dimension,
+    Manager,
+    Objective,
+    Session,
+)
 
 # Suppress FutureWarnings from Ax library
 warnings.filterwarnings("ignore", category=FutureWarning, module="ax.core.data")
 
 
-def max_lift_drag_objective(case: Case):
-    """
-    Calculate the lift coefficient from simulation results.
-
-    Args:
-        case: OpenFOAM case to extract lift coefficient from
-
-    Returns:
-        float: Last lift coefficient value, or None if data unavailable
-    """
-    my_func_obj = "forceCoeffsCompressible"
-    dataframe = case.data.simple_function_object_reader(my_func_obj)
-
+def lift_to_drag_ratio(case: Case):
+    """Calculate the lift to drag ratio from simulation results."""
+    dataframe = case.data.simple_function_object_reader("forceCoeffsCompressible")
     if dataframe is None:
         return None
+    return (
+        dataframe.select(pl.last("Cl")).item() / dataframe.select(pl.last("Cd")).item()
+    )
 
-    last_cl = dataframe.select(pl.last("Cl")).item()
-    last_cd = dataframe.select(pl.last("Cd")).item()
 
-    return last_cl / last_cd
+def lift_objective(case: Case):
+    """Calculate the lift coefficient from simulation results."""
+    dataframe = case.data.simple_function_object_reader("forceCoeffsCompressible")
+    if dataframe is None:
+        return None
+    return dataframe.select(pl.last("Cl")).item()
 
 
 if __name__ == "__main__":
     coloredlogs.install(level="INFO")
 
-    data_dir = Path("flowboost_data")
-
+    # --- Session ---
     session = Session(
         name="aerofoilNACA0012Steady",
-        data_dir=data_dir,
+        data_dir=Path("flowboost_data"),
         clone_method="copy",
+        random_seed=0,
+        target_value=60.8,  # Target lift-to-drag ratio
         max_evaluations=50,
     )
 
-    # Define a template case
-    case_dir = Path(data_dir, "aerofoilNACA0012Steady_template")
+    # --- Template case ---
     naca_case = Case.from_tutorial(
-        "fluid/aerofoilNACA0012Steady", case_dir, method="copy"
+        "fluid/aerofoilNACA0012Steady",
+        Path(session.data_dir, "aerofoilNACA0012Steady_template"),
+        method="copy",
     )
-
-    # Set writeInterval to 5000 to avoid writing excessive fields
-    control_dict = naca_case.dictionary("system/controlDict")
-    control_dict.entry("writeInterval").set("5000")
-
-    # Attach template case to session
+    naca_case.dictionary("system/controlDict").entry("writeInterval").set("5000")
     session.attach_template_case(case=naca_case)
 
-    # Define optimization objective
+    # --- Objectives ---
+
     objective = Objective(
-        name="L/D",
+        name="Lift_to_Drag",
         minimize=False,
-        objective_function=max_lift_drag_objective,
+        objective_function=lift_to_drag_ratio,
     )
 
-    session.backend.set_objectives([objective])
+    constraint = Constraint(
+        name="Lift_Constraint",
+        objective_function=lift_objective,
+        gte=1,  # Ensure lift coefficient is above 1
+    )
 
-    # Define search space dimensions
+    # --- Search space ---
     DICT_FILE = "0/U"
-    # Angle of attack dimension
-    ENTRY_PATH_AOA = "angleOfAttack"
-    entry_link_aoa = Dictionary.link(DICT_FILE).entry(ENTRY_PATH_AOA)
+
     aoa_dim = Dimension.range(
-        name="angleOfAttack", link=entry_link_aoa, lower=-20, upper=40, log_scale=False
+        name="angleOfAttack",
+        link=Dictionary.link(DICT_FILE).entry("angleOfAttack"),
+        lower=-20,
+        upper=40,
     )
 
-    # Speed dimension
-    ENTRY_PATH_AOA = "speed"
-    entry_link_speed = Dictionary.link(DICT_FILE).entry(ENTRY_PATH_AOA)
     speed_dim = Dimension.choice(
-        name="speed", link=entry_link_speed, choices=[10, 15, 20]
+        name="speed",
+        link=Dictionary.link(DICT_FILE).entry("speed"),
+        choices=[10, 15, 20],
     )
 
-    session.backend.set_search_space([aoa_dim, speed_dim])
+    session.configure_optimization(
+        objectives=[objective],
+        constraints=[constraint],
+        search_space=[aoa_dim, speed_dim],
+    )
 
-    # Configure job manager
-    scheduler = "Local"  # Change to "sge" for cluster
-
-    if not session.job_manager:
-        session.job_manager = Manager.create(
-            scheduler=scheduler, wdir=session.data_dir, job_limit=5
-        )
-
+    # --- Job manager ---
+    session.job_manager = session.job_manager or Manager.create(
+        scheduler="Local",
+        wdir=session.data_dir,
+        job_limit=2,
+    )
     session.job_manager.monitoring_interval = 10
-    session.backend.initialization_trials = 4
+
+    # --- Run ---
+    session.backend.initialization_trials = 8
     session.clean_pending_cases()
     session.start()

--- a/examples/aerofoilNACA0012Steady/visualise.py
+++ b/examples/aerofoilNACA0012Steady/visualise.py
@@ -1,253 +1,659 @@
 import json
-import matplotlib.pyplot as plt
+import itertools
 from pathlib import Path
+import matplotlib.pyplot as plt
 import matplotlib.animation as animation
-from matplotlib.animation import PillowWriter
-from mpl_toolkits.mplot3d import Axes3D  # noqa: F401
+import matplotlib.colors as mcolors
 import numpy as np
-import matplotlib as mpl
+from matplotlib.lines import Line2D
+from matplotlib.cm import ScalarMappable
 
-mpl.rcParams.update({
-    'font.size': 16,
-    'axes.titlesize': 20,
-    'axes.labelsize': 17,
-    'xtick.labelsize': 15,
-    'ytick.labelsize': 15,
-    'legend.fontsize': 15,
-})
-
-# -----------------------------
-# Load designs data
-# -----------------------------
-designs_file = Path("flowboost_data/designs.json")
-with open(designs_file, "r") as f:
+# --- Load ---
+data_path = Path(__file__).parent / "flowboost_data/designs.json"
+with open(data_path) as f:
     data = json.load(f)
 
-designs = data["designs"]
+designs = sorted(data["designs"], key=lambda d: d["created_at"])
+output_dir = Path(__file__).parent / "figures"
+output_dir.mkdir(exist_ok=True)
 
-# -----------------------------
-# Extract relevant data
-# -----------------------------
-design_data = []
+param_keys = list({k for d in designs for k in d.get("parameters", {})})
+obj_keys = list({k for d in designs for k in d.get("objectives", {})})
+con_keys = list({k for d in designs for k in d.get("constraints", {})})
 
-for design in designs:
-    params = design.get("parameters", {})
-    objectives = design.get("objectives", {})
+CMAP = plt.cm.viridis
+ALPHA_FEAS = 1.0
+ALPHA_INFEAS = 0.2
+VMIN = 0
+VMAX = len(designs) - 1
+NORM = mcolors.Normalize(vmin=VMIN, vmax=VMAX)
 
-    aoa = params.get("angleOfAttack")
-    speed = params.get("speed")
-    LD = objectives.get("L/D", {}).get("value")
-    gen_index = design.get("generation_index", "0")
 
-    if aoa is not None and speed is not None and LD is not None:
-        design_data.append({
-            "gen_index": gen_index,
-            "angleOfAttack": aoa,
-            "speed": speed,
-            "L/D": LD
-        })
+def get_param(d, key):
+    return d.get("parameters", {}).get(key)
 
-# Sort by numeric generation index
-def gen_to_float(g):
-    try:
-        return float(g)
-    except ValueError:
-        return 0.0
 
-design_data.sort(key=lambda x: gen_to_float(x["gen_index"]))
+def get_obj(d, key):
+    return d.get("objectives", {}).get(key, {}).get("value")
 
-# -----------------------------
-# Prepare arrays
-# -----------------------------
-aoas = [d["angleOfAttack"] for d in design_data]
-speeds = [d["speed"] for d in design_data]
-LDs = [d["L/D"] for d in design_data]
 
-iterations = list(range(1, len(LDs) + 1))
+def get_con(d, key):
+    return d.get("constraints", {}).get(key, {}).get("value")
 
-# Cumulative best (maximize LD)
-cumulative_best = []
-current_best = LDs[0]
-for v in LDs:
-    current_best = max(current_best, v)
-    cumulative_best.append(current_best)
 
-# -----------------------------
-# Fixed global axis limits (NO jitter)
-# -----------------------------
-aoa_min, aoa_max = min(aoas), max(aoas)
-spd_min, spd_max = min(speeds), max(speeds)
-LD_min, LD_max = min(LDs), max(LDs)
+def feasible(d):
+    for key, con in d.get("constraints", {}).items():
+        v = con.get("value")
+        if v is None:
+            continue
+        if con.get("gte") is not None and v < con["gte"]:
+            return False
+        if con.get("lte") is not None and v > con["lte"]:
+            return False
+    return True
 
-aoa_pad = 0.1 * (aoa_max - aoa_min if aoa_max != aoa_min else 1.0)
-spd_pad = 0.1 * (spd_max - spd_min if spd_max != spd_min else 1.0)
-LD_pad = 0.1 * (LD_max - LD_min if LD_max != LD_min else 1.0)
 
-AOA_LIM = (aoa_min - aoa_pad, aoa_max + aoa_pad)
-SPD_LIM = (spd_min - spd_pad, spd_max + spd_pad)
-LD_LIM = (LD_min - LD_pad, LD_max + LD_pad)
+def is_dominated(vals, i, minimizes):
+    for j, other in enumerate(vals):
+        if j == i:
+            continue
+        dominates = True
+        strictly = False
+        for k, (vi, vj) in enumerate(zip(vals[i], other)):
+            if minimizes[k]:
+                if vj > vi:
+                    dominates = False
+                    break
+                if vj < vi:
+                    strictly = True
+            else:
+                if vj < vi:
+                    dominates = False
+                    break
+                if vj > vi:
+                    strictly = True
+        if dominates and strictly:
+            return True
+    return False
 
-# -----------------------------
-# Figure & axes
-# -----------------------------
-fig = plt.figure(figsize=(12, 18))
 
-ax1 = fig.add_subplot(3, 1, 1)
-ax4 = fig.add_subplot(3, 1, (2, 3), projection="3d")
+def add_colorbar(fig, ax):
+    sm = ScalarMappable(cmap=CMAP, norm=NORM)
+    sm.set_array([])
+    cbar = fig.colorbar(sm, ax=ax, pad=0.02)
+    cbar.set_label("Design index (older → newer)")
 
-plt.subplots_adjust(hspace=0.35)
 
-# Top plot lines
-line1, = ax1.plot([], [], "o-", alpha=0.6, label="Individual runs")
-line2, = ax1.plot([], [], "r-", lw=2, label="Best so far")
+def scatter_with_feasibility(ax, xs, ys, indices, feas_flags):
+    f_x = [x for x, f in zip(xs, feas_flags) if f]
+    f_y = [y for y, f in zip(ys, feas_flags) if f]
+    f_i = [i for i, f in zip(indices, feas_flags) if f]
+    if_x = [x for x, f in zip(xs, feas_flags) if not f]
+    if_y = [y for y, f in zip(ys, feas_flags) if not f]
+    if_i = [i for i, f in zip(indices, feas_flags) if not f]
+    if if_x:
+        ax.scatter(
+            if_x,
+            if_y,
+            c=if_i,
+            cmap=CMAP,
+            norm=NORM,
+            alpha=ALPHA_INFEAS,
+            zorder=2,
+            edgecolors="none",
+        )
+    if f_x:
+        ax.scatter(
+            f_x,
+            f_y,
+            c=f_i,
+            cmap=CMAP,
+            norm=NORM,
+            alpha=ALPHA_FEAS,
+            zorder=3,
+            edgecolors="none",
+        )
 
-# -----------------------------
-# Top plot formatting
-# -----------------------------
-ax1.set_xlim(0, len(LDs) + 1)
-lmin, lmax = min(LDs), max(LDs)
-ax1.set_ylim(
-    lmin * 1.1 if lmin < 0 else lmin * 0.9,
-    lmax * 1.1 if lmax > 0 else lmax * 0.9
-)
 
-ax1.set_xlabel("Iteration", fontsize=14)
-ax1.set_ylabel("L/D", fontsize=14)
-ax1.set_title("Optimization Progress: LD vs Iteration", fontsize=16)
-ax1.legend(loc="lower right",fontsize=12)
-ax1.grid(alpha=0.3)
-ax1.tick_params(labelsize=12)
+# ===========================================================================
+# STATIC FIGURES
+# ===========================================================================
 
-# Sobol shading
-num_sobol = min(4, len(LDs))
-ax1.axvspan(0, num_sobol, alpha=0.15, color="green", label="Sobol")
+for obj_key in obj_keys:
+    for param_key in param_keys:
+        valid = [
+            (i, d)
+            for i, d in enumerate(designs)
+            if get_param(d, param_key) is not None and get_obj(d, obj_key) is not None
+        ]
+        indices = [i for i, _ in valid]
+        xs = [get_param(d, param_key) for _, d in valid]
+        ys = [get_obj(d, obj_key) for _, d in valid]
+        feas = [feasible(d) for _, d in valid]
 
-stats_text = ax1.text(
-    0.02, 0.98, "",
-    transform=ax1.transAxes,
-    va="top",
-    fontsize=15,
-    bbox=dict(boxstyle="round", facecolor="wheat", alpha=0.5)
-)
+        fig, ax = plt.subplots()
+        scatter_with_feasibility(ax, xs, ys, indices, feas)
+        add_colorbar(fig, ax)
+        ax.set_xlabel(param_key)
+        ax.set_ylabel(obj_key)
+        ax.set_title(f"{obj_key} vs {param_key}")
+        ax.grid(True)
+        fname = output_dir / f"obj_{obj_key}_vs_{param_key}.png"
+        fig.savefig(fname, dpi=150, bbox_inches="tight")
+        plt.close(fig)
+        print(f"Saved {fname}")
 
-# -----------------------------
-# Helper function to draw transparent planes
-# -----------------------------
-def draw_best_planes(ax, aoa_best, speed_best):
-    # Plane at AoA = aoa_best (speed × LD)
-    speed_grid, LD_grid = np.meshgrid(
-        np.linspace(*SPD_LIM, 20),
-        np.linspace(*LD_LIM, 20)
+for con_key in con_keys:
+    for param_key in param_keys:
+        valid = [
+            (i, d)
+            for i, d in enumerate(designs)
+            if get_param(d, param_key) is not None and get_con(d, con_key) is not None
+        ]
+        indices = [i for i, _ in valid]
+        xs = [get_param(d, param_key) for _, d in valid]
+        ys = [get_con(d, con_key) for _, d in valid]
+        feas = [feasible(d) for _, d in valid]
+
+        gte = next(
+            (
+                d.get("constraints", {}).get(con_key, {}).get("gte")
+                for d in designs
+                if d.get("constraints", {}).get(con_key, {}).get("gte") is not None
+            ),
+            None,
+        )
+        lte = next(
+            (
+                d.get("constraints", {}).get(con_key, {}).get("lte")
+                for d in designs
+                if d.get("constraints", {}).get(con_key, {}).get("lte") is not None
+            ),
+            None,
+        )
+
+        fig, ax = plt.subplots()
+        scatter_with_feasibility(ax, xs, ys, indices, feas)
+        add_colorbar(fig, ax)
+        handles = []
+        if gte is not None:
+            ax.axhline(gte, color="blue", linestyle="--")
+            handles.append(
+                Line2D([0], [0], color="blue", linestyle="--", label=f"gte={gte}")
+            )
+        if lte is not None:
+            ax.axhline(lte, color="orange", linestyle="--")
+            handles.append(
+                Line2D([0], [0], color="orange", linestyle="--", label=f"lte={lte}")
+            )
+        ax.set_xlabel(param_key)
+        ax.set_ylabel(con_key)
+        ax.set_title(f"{con_key} vs {param_key}")
+        ax.grid(True)
+        if handles:
+            ax.legend(handles=handles, loc="upper right")
+        fname = output_dir / f"con_{con_key}_vs_{param_key}.png"
+        fig.savefig(fname, dpi=150, bbox_inches="tight")
+        plt.close(fig)
+        print(f"Saved {fname}")
+
+# --- Pareto front static ---
+feasible_designs = [d for d in designs if feasible(d)]
+
+for obj_a, obj_b in itertools.combinations(obj_keys, 2):
+    valid_feas = [
+        (designs.index(d), d)
+        for d in feasible_designs
+        if get_obj(d, obj_a) is not None and get_obj(d, obj_b) is not None
+    ]
+    feas_vals = [(get_obj(d, obj_a), get_obj(d, obj_b)) for _, d in valid_feas]
+
+    min_a = designs[0].get("objectives", {}).get(obj_a, {}).get("minimize", True)
+    min_b = designs[0].get("objectives", {}).get(obj_b, {}).get("minimize", True)
+    minimizes = [min_a, min_b]
+
+    pareto_mask = [
+        not is_dominated(feas_vals, i, minimizes) for i in range(len(feas_vals))
+    ]
+
+    fig, ax = plt.subplots()
+    inf_designs = [
+        (designs.index(d), d)
+        for d in designs
+        if not feasible(d)
+        and get_obj(d, obj_a) is not None
+        and get_obj(d, obj_b) is not None
+    ]
+    if inf_designs:
+        ax.scatter(
+            [get_obj(d, obj_a) for _, d in inf_designs],
+            [get_obj(d, obj_b) for _, d in inf_designs],
+            c=[i for i, _ in inf_designs],
+            cmap=CMAP,
+            norm=NORM,
+            alpha=ALPHA_INFEAS,
+            zorder=2,
+            edgecolors="none",
+        )
+    non_pareto = [(idx, d) for (idx, d), p in zip(valid_feas, pareto_mask) if not p]
+    if non_pareto:
+        ax.scatter(
+            [get_obj(d, obj_a) for _, d in non_pareto],
+            [get_obj(d, obj_b) for _, d in non_pareto],
+            c=[i for i, _ in non_pareto],
+            cmap=CMAP,
+            norm=NORM,
+            alpha=ALPHA_FEAS,
+            zorder=3,
+            edgecolors="none",
+        )
+    pareto_pts = [(idx, d) for (idx, d), p in zip(valid_feas, pareto_mask) if p]
+    if pareto_pts:
+        px = [get_obj(d, obj_a) for _, d in pareto_pts]
+        py = [get_obj(d, obj_b) for _, d in pareto_pts]
+        ax.scatter(
+            px,
+            py,
+            c=[i for i, _ in pareto_pts],
+            cmap=CMAP,
+            norm=NORM,
+            alpha=ALPHA_FEAS,
+            zorder=4,
+            edgecolors="black",
+            linewidths=1.2,
+        )
+        sp = sorted(zip(px, py))
+        ax.plot(
+            [p[0] for p in sp], [p[1] for p in sp], c="gold", linestyle="--", zorder=3
+        )
+        ax.legend(
+            handles=[
+                Line2D(
+                    [0],
+                    [0],
+                    marker="o",
+                    color="w",
+                    markerfacecolor="grey",
+                    markeredgecolor="black",
+                    linestyle="None",
+                    label="Pareto front",
+                )
+            ],
+            loc="upper right",
+        )
+    add_colorbar(fig, ax)
+    ax.set_xlabel(f"{obj_a} ({'min' if min_a else 'max'})")
+    ax.set_ylabel(f"{obj_b} ({'min' if min_b else 'max'})")
+    ax.set_title(f"Pareto Front: {obj_a} vs {obj_b}")
+    ax.grid(True)
+    fname = output_dir / f"pareto_{obj_a}_vs_{obj_b}.png"
+    fig.savefig(fname, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    print(f"Saved {fname}")
+
+# ===========================================================================
+# ANIMATIONS
+# ===========================================================================
+
+
+def make_scatter_animation(
+    all_xs, all_ys, all_indices, all_feas, xlabel, ylabel, title, fname, hlines=None
+):
+    pad_x = (max(all_xs) - min(all_xs)) * 0.1 or 1
+    pad_y = (max(all_ys) - min(all_ys)) * 0.1 or 1
+
+    fig, ax = plt.subplots()
+    ax.set_xlim(min(all_xs) - pad_x, max(all_xs) + pad_x)
+    ax.set_ylim(min(all_ys) - pad_y, max(all_ys) + pad_y)
+    ax.set_xlabel(xlabel)
+    ax.set_ylabel(ylabel)
+    ax.set_title(title)
+    ax.grid(True)
+
+    if hlines:
+        handles = []
+        for hy, hc, hl in hlines:
+            ax.axhline(hy, color=hc, linestyle="--")
+            handles.append(Line2D([0], [0], color=hc, linestyle="--", label=hl))
+        ax.legend(handles=handles, loc="upper right")
+
+    # Use c=[] + vmin/vmax to avoid UserWarning about missing color data
+    scat_inf = ax.scatter(
+        [],
+        [],
+        c=[],
+        cmap=CMAP,
+        vmin=VMIN,
+        vmax=VMAX,
+        alpha=ALPHA_INFEAS,
+        zorder=2,
+        edgecolors="none",
     )
-    ax.plot_surface(
-        np.full_like(speed_grid, aoa_best),
-        speed_grid,
-        LD_grid,
-        alpha=0.15,
-        color="red",
-        linewidth=0,
-        zorder=0
+    scat_feas = ax.scatter(
+        [],
+        [],
+        c=[],
+        cmap=CMAP,
+        vmin=VMIN,
+        vmax=VMAX,
+        alpha=ALPHA_FEAS,
+        zorder=3,
+        edgecolors="none",
     )
-
-    # Plane at speed = speed_best (AoA × LD)
-    aoa_grid, LD_grid2 = np.meshgrid(
-        np.linspace(*AOA_LIM, 20),
-        np.linspace(*LD_LIM, 20)
+    step_text = ax.text(
+        0.02, 0.03, "", transform=ax.transAxes, verticalalignment="bottom", fontsize=9
     )
-    ax.plot_surface(
-        aoa_grid,
-        np.full_like(aoa_grid, speed_best),
-        LD_grid2,
-        alpha=0.15,
-        color="blue",
-        linewidth=0,
-        zorder=0
+    add_colorbar(fig, ax)
+
+    def init():
+        scat_inf.set_offsets(np.empty((0, 2)))
+        scat_inf.set_array(np.array([], dtype=float))
+        scat_feas.set_offsets(np.empty((0, 2)))
+        scat_feas.set_array(np.array([], dtype=float))
+        step_text.set_text("")
+        return scat_inf, scat_feas, step_text
+
+    def update(frame):
+        n = frame + 1
+        xs_n = all_xs[:n]
+        ys_n = all_ys[:n]
+        idx_n = all_indices[:n]
+        feas_n = all_feas[:n]
+
+        if_pts = [(x, y, i) for x, y, i, f in zip(xs_n, ys_n, idx_n, feas_n) if not f]
+        f_pts = [(x, y, i) for x, y, i, f in zip(xs_n, ys_n, idx_n, feas_n) if f]
+
+        if if_pts:
+            scat_inf.set_offsets(np.array([(x, y) for x, y, _ in if_pts]))
+            scat_inf.set_array(np.array([i for _, _, i in if_pts], dtype=float))
+        else:
+            scat_inf.set_offsets(np.empty((0, 2)))
+            scat_inf.set_array(np.array([], dtype=float))
+
+        if f_pts:
+            scat_feas.set_offsets(np.array([(x, y) for x, y, _ in f_pts]))
+            scat_feas.set_array(np.array([i for _, _, i in f_pts], dtype=float))
+        else:
+            scat_feas.set_offsets(np.empty((0, 2)))
+            scat_feas.set_array(np.array([], dtype=float))
+
+        step_text.set_text(f"Designs: {n}/{len(all_xs)}")
+        return scat_inf, scat_feas, step_text
+
+    ani = animation.FuncAnimation(
+        fig,
+        update,
+        frames=len(all_xs),
+        init_func=init,
+        blit=True,
+        interval=600,
+        repeat_delay=1500,
     )
+    ani.save(fname, writer="pillow", dpi=120)
+    plt.close(fig)
+    print(f"Saved {fname}")
 
-# -----------------------------
-# Animation function
-# -----------------------------
-def animate(frame):
-    k = frame + 1
 
-    x = iterations[:k]
-    y = LDs[:k]
-    best = cumulative_best[:k]
+# Animate objectives vs parameters
+for obj_key in obj_keys:
+    for param_key in param_keys:
+        valid = [
+            (i, d)
+            for i, d in enumerate(designs)
+            if get_param(d, param_key) is not None and get_obj(d, obj_key) is not None
+        ]
+        indices = [i for i, _ in valid]
+        xs = [get_param(d, param_key) for _, d in valid]
+        ys = [get_obj(d, obj_key) for _, d in valid]
+        feas = [feasible(d) for _, d in valid]
+        fname = output_dir / f"obj_{obj_key}_vs_{param_key}.gif"
+        make_scatter_animation(
+            xs,
+            ys,
+            indices,
+            feas,
+            xlabel=param_key,
+            ylabel=obj_key,
+            title=f"{obj_key} vs {param_key}",
+            fname=fname,
+        )
 
-    # Update top plot
-    line1.set_data(x, y)
-    line2.set_data(x, best)
+# Animate constraints vs parameters
+for con_key in con_keys:
+    for param_key in param_keys:
+        valid = [
+            (i, d)
+            for i, d in enumerate(designs)
+            if get_param(d, param_key) is not None and get_con(d, con_key) is not None
+        ]
+        indices = [i for i, _ in valid]
+        xs = [get_param(d, param_key) for _, d in valid]
+        ys = [get_con(d, con_key) for _, d in valid]
+        feas = [feasible(d) for _, d in valid]
 
-    best_idx = y.index(max(y))
-    aoa_best = aoas[best_idx]
-    speed_best = speeds[best_idx]
+        gte = next(
+            (
+                d.get("constraints", {}).get(con_key, {}).get("gte")
+                for d in designs
+                if d.get("constraints", {}).get(con_key, {}).get("gte") is not None
+            ),
+            None,
+        )
+        lte = next(
+            (
+                d.get("constraints", {}).get(con_key, {}).get("lte")
+                for d in designs
+                if d.get("constraints", {}).get(con_key, {}).get("lte") is not None
+            ),
+            None,
+        )
+        hlines = []
+        if gte is not None:
+            hlines.append((gte, "blue", f"gte={gte}"))
+        if lte is not None:
+            hlines.append((lte, "orange", f"lte={lte}"))
 
-    # --- 3D plot ---
-    ax4.clear()
-    ax4.set_xlim(*AOA_LIM)
-    ax4.set_ylim(*SPD_LIM)
-    ax4.set_zlim(*LD_LIM)
+        fname = output_dir / f"con_{con_key}_vs_{param_key}.gif"
+        make_scatter_animation(
+            xs,
+            ys,
+            indices,
+            feas,
+            xlabel=param_key,
+            ylabel=con_key,
+            title=f"{con_key} vs {param_key}",
+            fname=fname,
+            hlines=hlines or None,
+        )
 
-    # Draw transparent planes
-    draw_best_planes(ax4, aoa_best, speed_best)
+# Animate Pareto front
+for obj_a, obj_b in itertools.combinations(obj_keys, 2):
+    min_a = designs[0].get("objectives", {}).get(obj_a, {}).get("minimize", True)
+    min_b = designs[0].get("objectives", {}).get(obj_b, {}).get("minimize", True)
+    minimizes = [min_a, min_b]
 
-    # Scatter points
-    ax4.scatter(
-        aoas[:k],
-        speeds[:k],
-        y,
-        c=y,
-        cmap="viridis",
-        s=80,
+    valid = [
+        (i, d, feasible(d))
+        for i, d in enumerate(designs)
+        if get_obj(d, obj_a) is not None and get_obj(d, obj_b) is not None
+    ]
+    all_xs = [get_obj(d, obj_a) for _, d, _ in valid]
+    all_ys = [get_obj(d, obj_b) for _, d, _ in valid]
+    all_idx = [i for i, _, _ in valid]
+    all_feas = [f for _, _, f in valid]
+
+    pad_x = (max(all_xs) - min(all_xs)) * 0.1 or 1
+    pad_y = (max(all_ys) - min(all_ys)) * 0.1 or 1
+
+    fig, ax = plt.subplots()
+    ax.set_xlim(min(all_xs) - pad_x, max(all_xs) + pad_x)
+    ax.set_ylim(min(all_ys) - pad_y, max(all_ys) + pad_y)
+    ax.set_xlabel(f"{obj_a} ({'min' if min_a else 'max'})")
+    ax.set_ylabel(f"{obj_b} ({'min' if min_b else 'max'})")
+    ax.set_title(f"Pareto Front: {obj_a} vs {obj_b}")
+    ax.grid(True)
+
+    scat_inf = ax.scatter(
+        [],
+        [],
+        c=[],
+        cmap=CMAP,
+        vmin=VMIN,
+        vmax=VMAX,
+        alpha=ALPHA_INFEAS,
+        zorder=2,
+        edgecolors="none",
+    )
+    scat_feas = ax.scatter(
+        [],
+        [],
+        c=[],
+        cmap=CMAP,
+        vmin=VMIN,
+        vmax=VMAX,
+        alpha=ALPHA_FEAS,
+        zorder=3,
+        edgecolors="none",
+    )
+    scat_pareto = ax.scatter(
+        [],
+        [],
+        c=[],
+        cmap=CMAP,
+        vmin=VMIN,
+        vmax=VMAX,
+        alpha=ALPHA_FEAS,
+        zorder=4,
         edgecolors="black",
-        alpha=0.85
+        linewidths=1.2,
+    )
+    (pareto_line,) = ax.plot([], [], c="gold", linestyle="--", zorder=3)
+    step_text = ax.text(
+        0.02, 0.03, "", transform=ax.transAxes, verticalalignment="bottom", fontsize=9
+    )
+    add_colorbar(fig, ax)
+    ax.legend(
+        handles=[
+            Line2D(
+                [0],
+                [0],
+                marker="o",
+                color="w",
+                markerfacecolor="grey",
+                markeredgecolor="black",
+                linestyle="None",
+                label="Pareto front",
+            )
+        ],
+        loc="upper right",
     )
 
-    # Best point
-    ax4.scatter(
-        [aoa_best],
-        [speed_best],
-        [y[best_idx]],
-        c="red",
-        s=150,
-        marker="*",
-        label=f"Best LD: {max(y):.3f}"
+    def make_pareto_update(all_xs, all_ys, all_idx, all_feas, minimizes):
+        def update(frame):
+            n = frame + 1
+            xs_n = all_xs[:n]
+            ys_n = all_ys[:n]
+            idx_n = all_idx[:n]
+            feas_n = all_feas[:n]
+
+            inf_data = [
+                (x, y, i) for x, y, i, f in zip(xs_n, ys_n, idx_n, feas_n) if not f
+            ]
+            feas_data = [
+                (x, y, i) for x, y, i, f in zip(xs_n, ys_n, idx_n, feas_n) if f
+            ]
+
+            if inf_data:
+                scat_inf.set_offsets(np.array([(x, y) for x, y, _ in inf_data]))
+                scat_inf.set_array(np.array([i for _, _, i in inf_data], dtype=float))
+            else:
+                scat_inf.set_offsets(np.empty((0, 2)))
+                scat_inf.set_array(np.array([], dtype=float))
+
+            feas_vals = [(x, y) for x, y, _ in feas_data]
+            if feas_vals:
+                pmask = [
+                    not is_dominated(feas_vals, i, minimizes)
+                    for i in range(len(feas_vals))
+                ]
+                non_p = [(x, y, i) for (x, y, i), m in zip(feas_data, pmask) if not m]
+                par_p = [(x, y, i) for (x, y, i), m in zip(feas_data, pmask) if m]
+
+                if non_p:
+                    scat_feas.set_offsets(np.array([(x, y) for x, y, _ in non_p]))
+                    scat_feas.set_array(np.array([i for _, _, i in non_p], dtype=float))
+                else:
+                    scat_feas.set_offsets(np.empty((0, 2)))
+                    scat_feas.set_array(np.array([], dtype=float))
+
+                if par_p:
+                    scat_pareto.set_offsets(np.array([(x, y) for x, y, _ in par_p]))
+                    scat_pareto.set_array(
+                        np.array([i for _, _, i in par_p], dtype=float)
+                    )
+                    sp = sorted([(x, y) for x, y, _ in par_p])
+                    pareto_line.set_data([p[0] for p in sp], [p[1] for p in sp])
+                else:
+                    scat_pareto.set_offsets(np.empty((0, 2)))
+                    scat_pareto.set_array(np.array([], dtype=float))
+                    pareto_line.set_data([], [])
+            else:
+                for s in (scat_feas, scat_pareto):
+                    s.set_offsets(np.empty((0, 2)))
+                    s.set_array(np.array([], dtype=float))
+                pareto_line.set_data([], [])
+
+            step_text.set_text(f"Designs: {n}/{len(all_xs)}")
+            return scat_inf, scat_feas, scat_pareto, pareto_line, step_text
+
+        return update
+
+    ani = animation.FuncAnimation(
+        fig,
+        make_pareto_update(all_xs, all_ys, all_idx, all_feas, minimizes),
+        frames=len(valid),
+        interval=600,
+        repeat_delay=1500,
+        blit=True,
     )
+    fname = output_dir / f"pareto_{obj_a}_vs_{obj_b}.gif"
+    ani.save(fname, writer="pillow", dpi=120)
+    plt.close(fig)
+    print(f"Saved {fname}")
 
-    ax4.set_xlabel("Angle of Attack [deg]", fontsize=17, labelpad=12)
-    ax4.set_ylabel("Speed", fontsize=17, labelpad=12)
-    ax4.set_zlabel("LD", fontsize=17, labelpad=12)
-    ax4.set_title("3D Design Space: AoA × Speed × LD", fontsize=20, pad=20)
-    ax4.tick_params(labelsize=15)
-    ax4.legend(loc="upper left", fontsize=14)
+print("Done.")
 
-    phase = "Sobol sampling" if k <= num_sobol else "Bayesian Optimization"
-    stats_text.set_text(
-        f"Iteration: {k}/{len(LDs)} ({phase})\n"
-        f"Current LD: {y[-1]:.4f}\n"
-        f"Best LD: {best[-1]:.4f}"
-    )
+# ===========================================================================
+# BEST DESIGN SUMMARY
+# ===========================================================================
+print("\n--- Best Feasible Designs ---")
+feasible_all = [d for d in designs if feasible(d)]
 
-    return line1, line2, stats_text
+if not feasible_all:
+    print("No feasible designs found.")
+else:
+    for obj_key in obj_keys:
+        valid = [d for d in feasible_all if get_obj(d, obj_key) is not None]
+        if not valid:
+            continue
+        minimize = valid[0].get("objectives", {}).get(obj_key, {}).get("minimize", True)
+        best = (
+            min(valid, key=lambda d: get_obj(d, obj_key))
+            if minimize
+            else max(valid, key=lambda d: get_obj(d, obj_key))
+        )
 
-# -----------------------------
-# Create & save animation
-# -----------------------------
-anim = animation.FuncAnimation(
-    fig,
-    animate,
-    frames=len(LDs),
-    interval=500,
-    blit=False
-)
-
-plt.tight_layout()
-
-print("Saving animation...")
-writer = PillowWriter(fps=2)
-anim.save("optimization_progress.gif", writer=writer, dpi=150)
-
-plt.savefig("optimization_progress.png", dpi=300, bbox_inches="tight")
-
-print(f"Frames: {len(LDs)}")
-print(f"Final best LD: {cumulative_best[-1]:.4f}")
+        print(f"\nBest for '{obj_key}' ({'minimize' if minimize else 'maximize'}):")
+        print(f"  Name       : {best['name']}")
+        print(f"  Created at : {best['created_at']}")
+        print("  Parameters :")
+        for k, v in best.get("parameters", {}).items():
+            print(f"    {k}: {v}")
+        print("  Objectives :")
+        for k, v in best.get("objectives", {}).items():
+            print(f"    {k}: {v.get('value')}")
+        print("  Constraints:")
+        for k, v in best.get("constraints", {}).items():
+            print(
+                f"    {k}: {v.get('value')}  (gte={v.get('gte')}, lte={v.get('lte')})"
+            )

--- a/examples/pitzDaily/pitzDaily.py
+++ b/examples/pitzDaily/pitzDaily.py
@@ -72,7 +72,6 @@ def main():
         minimize=True,
         objective_function=pressure_drop_objective,
     )
-    session.backend.set_objectives([objective])
 
     # Search space: inlet turbulence parameters (both are scalars)
     inlet_k = Dictionary.link("0/k").entry("boundaryField/inlet/value")
@@ -93,7 +92,10 @@ def main():
         log_scale=True,
     )
 
-    session.backend.set_search_space([k_dim, eps_dim])
+    session.configure_optimization(
+        objectives=[objective],
+        search_space=[k_dim, eps_dim],
+    )
 
     # Use DockerLocal manager — runs simulations in per-job Docker containers
     if not session.job_manager:

--- a/flowboost/__init__.py
+++ b/flowboost/__init__.py
@@ -8,8 +8,9 @@ if TYPE_CHECKING:
     from flowboost.openfoam.dictionary import Dictionary as Dictionary
     from flowboost.openfoam.runtime import get_runtime as foam_runtime
     from flowboost.optimizer.objectives import (
-        ScalarizedObjective as ScalarizedObjective,
+        Constraint as Constraint,
         Objective as Objective,
+        ScalarizedObjective as ScalarizedObjective,
     )
     from flowboost.optimizer.search_space import Dimension as Dimension
     from flowboost.session.session import Session as Session
@@ -22,6 +23,7 @@ def __getattr__(name):
         "PolarsData": "flowboost.openfoam.data",
         "Dictionary": "flowboost.openfoam.dictionary",
         "Dimension": "flowboost.optimizer.search_space",
+        "Constraint": "flowboost.optimizer.objectives",
         "Objective": "flowboost.optimizer.objectives",
         "ScalarizedObjective": "flowboost.optimizer.objectives",
         "Manager": "flowboost.manager.manager",
@@ -42,14 +44,15 @@ def __getattr__(name):
 
 
 __all__ = [
-    "ScalarizedObjective",
     "Case",
+    "Constraint",
     "Dictionary",
     "Dimension",
     "Manager",
     "Objective",
     "PandasData",
     "PolarsData",
+    "ScalarizedObjective",
     "Session",
     "foam_runtime",
 ]

--- a/flowboost/manager/manager.py
+++ b/flowboost/manager/manager.py
@@ -31,7 +31,7 @@ class Manager(ABC):
 
         # Limits
         self.job_limit: int = job_limit
-        self.monitoring_interval: int = 60
+        self.monitoring_interval: float = 60.0
 
         # Currently tracked jobs
         self.job_pool: set[JobV2] = set()

--- a/flowboost/openfoam/case.py
+++ b/flowboost/openfoam/case.py
@@ -22,7 +22,11 @@ from flowboost.optimizer.search_space import Dimension
 
 if TYPE_CHECKING:
     # Lazy imports for function argument typing
-    from flowboost.optimizer.objectives import Objective, ScalarizedObjective
+    from flowboost.optimizer.objectives import (
+        Constraint,
+        Objective,
+        ScalarizedObjective,
+    )
 
 DEFAULT_METADATA: str = "metadata.toml"
 GENERATION_INDEX_SORT_SENTINEL: str = "99999.99"
@@ -462,13 +466,15 @@ class Case:
         return entry.value
 
     def objective_function_outputs(
-        self, objectives: list[Union["Objective", "ScalarizedObjective"]]
+        self,
+        objectives: list[Union["Objective", "ScalarizedObjective", "Constraint"]],
     ) -> dict[str, float]:
         """Return {metric_name: value} for every metric this case contributes.
 
-        For a plain Objective the metric name is the objective's own name. For
-        a ScalarizedObjective each inner objective contributes its own metric
-        — Ax expects per-metric raw_data and does the scalarization itself.
+        Accepts the full set of metric-producing objects: plain Objectives,
+        a ScalarizedObjective (contributes one entry per inner objective), and
+        Constraints. The resulting dict is shaped exactly like the raw_data
+        Ax expects in `complete_trial`.
         """
         output_mapping: dict[str, float] = {}
 
@@ -476,7 +482,7 @@ class Case:
             metric_values = obj.metric_values_for_case(self)
             if not metric_values:
                 raise ValueError(
-                    f"Objective '{obj.name}' has no value for case {self}. The "
+                    f"Metric '{obj.name}' has no value for case {self}. The "
                     f"case has not been evaluated yet — run "
                     f"Backend.batch_process([case]) first, or fetch finished "
                     f"cases via Session.get_finished_cases(batch_process=True)."

--- a/flowboost/optimizer/backend.py
+++ b/flowboost/optimizer/backend.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any, Union
 
 from flowboost.openfoam.case import Case
-from flowboost.optimizer.objectives import Objective, ScalarizedObjective
+from flowboost.optimizer.objectives import Constraint, Objective, ScalarizedObjective
 from flowboost.optimizer.search_space import Dimension
 
 DEFAULT_OFFLOAD_RESULT_FNAME = "acquisition_result.json"
@@ -16,6 +16,7 @@ class Backend(ABC):
     def __init__(self) -> None:
         self.type: str = self.__class__.__name__
         self.objectives: list[Union[Objective, ScalarizedObjective]] = []
+        self.constraints: list[Constraint] = []
         self.dimensions: list[Dimension] = []
         self.offload_acquisition: bool = False
         self.random_seed: int | None = None
@@ -56,9 +57,31 @@ class Backend(ABC):
     def set_parameter_constraints(self, constraints: list[str]):
         pass
 
-    @abstractmethod
-    def set_outcome_constraints(self, constraints: list[str]):
-        pass
+    def set_constraints(self, constraints: Union[Constraint, list[Constraint]]):
+        """Register Constraint objects: tracking metrics that bound the
+        optimizer's exploration without being optimization targets.
+
+        Accepts either a single Constraint or an iterable of Constraints.
+        Rejects non-Constraint items up front so misuse surfaces here instead
+        of crashing later with an AttributeError inside the evaluation loop.
+        """
+        if isinstance(constraints, Constraint):
+            constraints = [constraints]
+        try:
+            constraints_list = list(constraints)
+        except TypeError as e:
+            raise TypeError(
+                f"set_constraints expects a Constraint or an iterable of "
+                f"Constraints, got {type(constraints).__name__!r}."
+            ) from e
+        for i, c in enumerate(constraints_list):
+            if not isinstance(c, Constraint):
+                raise TypeError(
+                    f"set_constraints[{i}] must be a Constraint, got "
+                    f"{type(c).__name__!r}. Use set_objectives() for "
+                    f"Objective and ScalarizedObjective."
+                )
+        self.constraints = constraints_list
 
     @abstractmethod
     def attach_pending_cases(self, cases: list[Case]):
@@ -169,7 +192,9 @@ class Backend(ABC):
             "finished_cases": {
                 c.name: {
                     "parametrization": c.parametrize_configuration(self.dimensions),
-                    "objectives": c.objective_function_outputs(self.objectives),
+                    "objectives": c.objective_function_outputs(
+                        [*self.objectives, *self.constraints]
+                    ),
                 }
                 for c in finished_cases
             },
@@ -210,24 +235,25 @@ class Backend(ABC):
         pass
 
     def batch_process(self, cases: list[Case]) -> list[list[float]]:
-        """Evaluate every objective on `cases` and persist results to metadata.
+        """Evaluate every objective and constraint on `cases` and persist
+        results to metadata.
 
-        Returns a list-of-lists shaped [num_objectives][num_successful_cases].
-        For a ScalarizedObjective, the returned row is the scalarized value;
-        per-inner-metric values are still cached on each inner Objective for
-        the backend to retrieve when telling Ax.
+        Returns a list-of-lists shaped [num_objectives][num_successful_cases]
+        of objective values. Constraint values are persisted to metadata but
+        not part of the return shape (constraints aren't optimization targets).
         """
         for objective in self.objectives:
             logging.info(f"Processing objective '{objective.name}'")
             objective.batch_evaluate(cases, save_values=True)
+        for constraint in self.constraints:
+            logging.info(f"Processing constraint '{constraint.name}'")
+            constraint.batch_evaluate(cases, save_values=True)
 
         successful_cases = [c for c in cases if c.success is not False]
         logging.info(f"Proceeding with {len(successful_cases)} successful case(s)")
         if not successful_cases:
             return []
 
-        # Values were coerced to float at evaluate() time; data_for_case is
-        # an unwrapped lookup, no re-coercion needed.
         final_outputs: list[list[float]] = [
             [objective.data_for_case(c) for c in successful_cases]
             for objective in self.objectives
@@ -236,17 +262,48 @@ class Backend(ABC):
         for case_idx, case in enumerate(successful_cases):
             objective_results: dict[str, Any] = {}
             for obj_idx, objective in enumerate(self.objectives):
-                objective_results[objective.name] = {
+                entry: dict[str, Any] = {
                     "value": final_outputs[obj_idx][case_idx],
                     "minimize": objective.minimize,
                 }
                 if isinstance(objective, ScalarizedObjective):
-                    objective_results[objective.name]["components"] = {
+                    entry["components"] = {
                         inner.name: inner.data_for_case(case)
                         for inner in objective.objectives
                     }
+                    component_bounds: dict[str, dict[str, float]] = {}
+                    for inner in objective.objectives:
+                        bounds: dict[str, float] = {}
+                        if inner.gte is not None:
+                            bounds["gte"] = inner.gte
+                        if inner.lte is not None:
+                            bounds["lte"] = inner.lte
+                        if bounds:
+                            component_bounds[inner.name] = bounds
+                    if component_bounds:
+                        entry["component_bounds"] = component_bounds
+                if isinstance(objective, Objective):
+                    if objective.gte is not None:
+                        entry["gte"] = objective.gte
+                    if objective.lte is not None:
+                        entry["lte"] = objective.lte
+                objective_results[objective.name] = entry
             case.update_metadata(objective_results, entry_header="objective-outputs")
-            logging.debug(f"Saved objective outputs to metadata for {case.name}")
+
+            if self.constraints:
+                constraint_results: dict[str, Any] = {}
+                for constraint in self.constraints:
+                    entry: dict[str, Any] = {"value": constraint.data_for_case(case)}
+                    if constraint.gte is not None:
+                        entry["gte"] = constraint.gte
+                    if constraint.lte is not None:
+                        entry["lte"] = constraint.lte
+                    constraint_results[constraint.name] = entry
+                case.update_metadata(
+                    constraint_results, entry_header="constraint-outputs"
+                )
+
+            logging.debug(f"Saved metric outputs to metadata for {case.name}")
 
         return final_outputs
 
@@ -283,6 +340,26 @@ class Backend(ABC):
     def _dim_names_are_unique(self) -> bool:
         return len(set([o.name for o in self.dimensions])) == len(self.dimensions)
 
+    def _all_metric_names(self) -> list[str]:
+        """Every metric name registered with the backend, across objectives
+        (including inner objectives of a ScalarizedObjective, and the derived
+        bound tracking metric emitted for each bounded Objective at either
+        the top level or inside a ScalarizedObjective) and constraints.
+        Used for cross-uniqueness validation."""
+        names: list[str] = []
+        for obj in self.objectives:
+            if isinstance(obj, ScalarizedObjective):
+                for inner in obj.objectives:
+                    names.append(inner.name)
+                    if inner.has_bounds:
+                        names.append(inner.bound_metric_name)
+            else:
+                names.append(obj.name)
+                if isinstance(obj, Objective) and obj.has_bounds:
+                    names.append(obj.bound_metric_name)
+        names.extend(c.name for c in self.constraints)
+        return names
+
     def _verify_configuration(self):
         """Verify a few key-parts of the backend configuration.
 
@@ -297,6 +374,17 @@ class Backend(ABC):
 
         if not self._dim_names_are_unique():
             raise ValueError("All Dimension names must be unique")
+
+        # Constraint names must not clash with objective metric names — Ax
+        # registers them all in the same metric namespace.
+        all_names = self._all_metric_names()
+        if len(set(all_names)) != len(all_names):
+            duplicates = sorted({n for n in all_names if all_names.count(n) > 1})
+            raise ValueError(
+                f"Metric names must be unique across objectives "
+                f"(including inner objectives of any ScalarizedObjective) "
+                f"and constraints. Duplicates: {', '.join(duplicates)}"
+            )
 
 
 class OptimizationComplete(Exception):

--- a/flowboost/optimizer/interfaces/Ax.py
+++ b/flowboost/optimizer/interfaces/Ax.py
@@ -10,8 +10,18 @@ from ax.core.base_trial import BaseTrial
 from ax.exceptions.core import DataRequiredError
 from ax.service.ax_client import AxClient, ObjectiveProperties, TParameterization
 
+from ax.core.metric import Metric
+from ax.core.objective import MultiObjective as AxMultiObjective
 from ax.core.objective import ScalarizedObjective as AxScalarizedObjective
-from ax.core.optimization_config import OptimizationConfig
+from ax.core.optimization_config import (
+    MultiObjectiveOptimizationConfig,
+    OptimizationConfig,
+)
+from ax.core.outcome_constraint import (
+    ObjectiveThreshold,
+    OutcomeConstraint,
+)
+from ax.core.types import ComparisonOp
 
 from flowboost.openfoam.case import Case
 from flowboost.optimizer.backend import Backend, OptimizationComplete
@@ -49,7 +59,6 @@ class AxBackend(Backend):
 
         # Ax-specific constraints
         self._parameter_constraints: list[str] = []
-        self._outcome_constraints: list[str] = []
 
         # Ax-specific features for noise
         self._SEM_by_objective: dict[str, Optional[float]] = {}
@@ -86,12 +95,14 @@ class AxBackend(Backend):
                     "the surrogate benefits from more sequential observations."
                 )
 
-        # Create a stateless optimizer client
+        # Create a stateless optimizer client. Outcome constraints aren't
+        # passed via the string-DSL kwarg here — they're installed structurally
+        # by `_install_optimization_config_overrides` once the experiment exists,
+        # so the metric references stay typed (vs. parsed from strings).
         self.client.create_experiment(
             parameters=self._get_ax_search_space(),
             objectives=self._get_ax_objectives(),
             parameter_constraints=self._parameter_constraints,
-            outcome_constraints=self._outcome_constraints,
             choose_generation_strategy_kwargs={
                 "num_initialization_trials": num_init,
                 "use_saasbo": self.SAASBO,
@@ -109,7 +120,7 @@ class AxBackend(Backend):
             },
         )
 
-        self._maybe_install_scalarized_objective()
+        self._install_optimization_config_overrides()
 
         # Outcome standardization is handled by Ax: the BoTorch generator's
         # default transform stack applies BilogY → StandardizeY before model
@@ -312,9 +323,6 @@ class AxBackend(Backend):
         """
         self._parameter_constraints = constraints
 
-    def set_outcome_constraints(self, constraints: list[str]):
-        self._outcome_constraints = constraints
-
     def attach_pending_cases(self, cases: list[Case]):
         if cases:
             logging.info(f"Attaching {len(cases)} pending case(s) to the model")
@@ -430,10 +438,14 @@ class AxBackend(Backend):
 
         # TODO handle failure criteria here
 
-        # Next, get the objective function outputs for each case
-        logging.info("Retrieving objective function outputs")
+        # Gather metric values for every registered objective AND constraint —
+        # Ax expects raw_data to cover all metrics it knows about, including
+        # tracking metrics referenced by outcome constraints. Missing any
+        # one of them silently marks the trial failed.
+        logging.info("Retrieving metric values for case completion")
+        registered_metrics = [*self.objectives, *self.constraints]
         case_objective_outputs: dict[Case, dict] = {
-            c: c.objective_function_outputs(self.objectives) for c in cases
+            c: c.objective_function_outputs(registered_metrics) for c in cases
         }
 
         logging.info(f"Ax search space: {self._get_ax_search_space()}")
@@ -618,7 +630,7 @@ class AxBackend(Backend):
         For top-level Objectives, the objective is the metric. For a top-level
         ScalarizedObjective, each inner Objective is registered as its own
         metric so Ax models them independently; the single-objective scalarized
-        OptimizationConfig is then installed by `_maybe_install_scalarized_objective`.
+        OptimizationConfig is then installed by `_install_optimization_config_overrides`.
         """
         ax_objectives: dict[str, ObjectiveProperties] = {}
         for objective in self.objectives:
@@ -634,34 +646,142 @@ class AxBackend(Backend):
 
         return ax_objectives
 
-    def _maybe_install_scalarized_objective(self) -> None:
-        """Swap in Ax's native ScalarizedObjective when the user asked for one.
+    def _install_optimization_config_overrides(self) -> None:
+        """Install structural overrides that AxClient.create_experiment can't
+        express directly: native ScalarizedObjective for the optimization
+        target, and OutcomeConstraints derived from gte/lte fields on
+        Objectives or pure Constraint instances.
 
-        AxClient.create_experiment treats multi-metric input as MOO by default;
-        we override the optimization_config so the inner metrics are scalarized
-        at the acquisition step. Each metric still has its own surrogate and
-        its own StandardizeY — that's the win over computing the weighted sum
-        upstream.
+        For each Constraint, also registers a tracking metric on the
+        experiment so Ax knows about the metric name when it appears in
+        raw_data during tell(). Without this registration, the trial is
+        silently marked failed by AxClient (it expects raw_data to cover
+        only registered metrics).
+
+        If neither overrides nor constraints are present, leaves Ax's default
+        config in place.
         """
         scalarized = [o for o in self.objectives if isinstance(o, ScalarizedObjective)]
-        if not scalarized:
+        bounded_objectives = list(self._iter_bounded_objectives())
+        if not scalarized and not self.constraints and not bounded_objectives:
             return
 
-        flowboost_obj = scalarized[0]
-        # Reuse the Metric objects Ax already registered for the inner
-        # objectives in `_get_ax_objectives`; constructing fresh ones here
-        # would re-encode `lower_is_better` and invite the two paths to drift.
-        metrics = [
-            self.client.experiment.metrics[inner.name]
-            for inner in flowboost_obj.objectives
-        ]
-        self.client.experiment.optimization_config = OptimizationConfig(
-            objective=AxScalarizedObjective(
+        # Register Constraint metrics as tracking metrics so they exist in
+        # experiment.metrics before we reference them in OutcomeConstraints
+        # (and so AxClient expects their values in raw_data).
+        for c in self.constraints:
+            if c.name not in self.client.experiment.metrics:
+                self.client.experiment.add_tracking_metric(Metric(name=c.name))
+
+        # Register derived bound metrics for Objectives carrying gte/lte.
+        # Ax rejects OutcomeConstraints attached to objective metrics, so the
+        # bound is hung off a sibling tracking metric whose value mirrors the
+        # objective's at tell() time.
+        for obj in bounded_objectives:
+            if obj.bound_metric_name not in self.client.experiment.metrics:
+                self.client.experiment.add_tracking_metric(
+                    Metric(name=obj.bound_metric_name)
+                )
+
+        # Pick the objective: existing one if no ScalarizedObjective override,
+        # otherwise build an Ax-native ScalarizedObjective referencing the
+        # already-registered inner metrics.
+        if scalarized:
+            flowboost_obj = scalarized[0]
+            metrics = [
+                self.client.experiment.metrics[inner.name]
+                for inner in flowboost_obj.objectives
+            ]
+            ax_objective = AxScalarizedObjective(
                 metrics=metrics,
                 weights=flowboost_obj.weights,
                 minimize=flowboost_obj.minimize,
             )
-        )
+        else:
+            ax_objective = self.client.experiment.optimization_config.objective
+
+        outcome_constraints = self._build_outcome_constraints()
+
+        # MultiObjective requires the MOO-flavored config (which carries the
+        # objective_thresholds field). Keep any thresholds Ax inferred for us
+        # at create_experiment time so we don't drop user-set ones.
+        if isinstance(ax_objective, AxMultiObjective):
+            existing = self.client.experiment.optimization_config
+            existing_thresholds: list[ObjectiveThreshold] = list(
+                getattr(existing, "objective_thresholds", []) or []
+            )
+            self.client.experiment.optimization_config = (
+                MultiObjectiveOptimizationConfig(
+                    objective=ax_objective,
+                    outcome_constraints=outcome_constraints,
+                    objective_thresholds=existing_thresholds,
+                )
+            )
+        else:
+            self.client.experiment.optimization_config = OptimizationConfig(
+                objective=ax_objective,
+                outcome_constraints=outcome_constraints,
+            )
+
+    def _build_outcome_constraints(self) -> list[OutcomeConstraint]:
+        """Build OutcomeConstraints from the gte/lte on each registered
+        Constraint and from the gte/lte on each bounded Objective (whose
+        bounds are hung off a derived tracking metric named
+        ``{obj.name}__bound``). Bounds are absolute (`relative=False`) — Ax
+        defaults to relative, which would silently change the meaning of
+        every constraint.
+
+        Assumes the relevant tracking metrics have already been registered
+        on the experiment.
+        """
+        constraints: list[OutcomeConstraint] = []
+        for c in self.constraints:
+            metric = self.client.experiment.metrics[c.name]
+            if c.gte is not None:
+                constraints.append(
+                    OutcomeConstraint(
+                        metric=metric, op=ComparisonOp.GEQ, bound=c.gte, relative=False
+                    )
+                )
+            if c.lte is not None:
+                constraints.append(
+                    OutcomeConstraint(
+                        metric=metric, op=ComparisonOp.LEQ, bound=c.lte, relative=False
+                    )
+                )
+        for obj in self._iter_bounded_objectives():
+            metric = self.client.experiment.metrics[obj.bound_metric_name]
+            if obj.gte is not None:
+                constraints.append(
+                    OutcomeConstraint(
+                        metric=metric,
+                        op=ComparisonOp.GEQ,
+                        bound=obj.gte,
+                        relative=False,
+                    )
+                )
+            if obj.lte is not None:
+                constraints.append(
+                    OutcomeConstraint(
+                        metric=metric,
+                        op=ComparisonOp.LEQ,
+                        bound=obj.lte,
+                        relative=False,
+                    )
+                )
+        return constraints
+
+    def _iter_bounded_objectives(self):
+        """Walk every `Objective` carrying `gte`/`lte`, whether registered
+        directly or as an inner term of a `ScalarizedObjective`. Each yielded
+        Objective has `has_bounds == True` and a `bound_metric_name`."""
+        for obj in self.objectives:
+            if isinstance(obj, ScalarizedObjective):
+                for inner in obj.objectives:
+                    if inner.has_bounds:
+                        yield inner
+            elif isinstance(obj, Objective) and obj.has_bounds:
+                yield obj
 
     def _dim_to_Ax_parameter_dict(self, dim: Dimension) -> dict[str, Any]:
         d: dict[str, Any] = {

--- a/flowboost/optimizer/objectives.py
+++ b/flowboost/optimizer/objectives.py
@@ -7,84 +7,23 @@ from flowboost.openfoam.case import Case
 from flowboost.optimizer.scalars import coerce_objective_scalar
 
 
-class Objective:
-    """A named optimization objective that evaluates a Case and returns a
-    scalar value.
-
-    Outcome standardization is the optimizer backend's job (Ax wraps every
-    metric in StandardizeY + BoTorch's Standardize). Don't add normalization
-    here. If your measurement is naturally non-linear (log-distributed drag,
-    say), pass `static_transform=math.log` — a pure float→float function,
-    applied per evaluation, no fitting, no state.
+class _EvaluatedMetric:
+    """Cache + lookup machinery shared by every class that produces a scalar
+    metric value from a Case (Objective, Constraint, ScalarizedObjective).
+    Subclasses must implement `evaluate()`; `metric_values_for_case()` may be
+    overridden when the class contributes more than one Ax metric.
+    Not part of the public API.
     """
 
-    def __init__(
-        self,
-        name: str,
-        minimize: bool,
-        objective_function: Callable,
-        objective_function_kwargs: Optional[dict[str, Any]] = None,
-        threshold: Optional[float] = None,
-        static_transform: Optional[Callable[[float], float]] = None,
-    ) -> None:
-        """An optimization objective for an OpenFOAM simulation.
-
-        Args:
-            name: Identifier for the objective. Must be unique across all
-                metrics in the experiment (including those wrapped in a
-                ScalarizedObjective).
-            minimize: True to minimize, False to maximize.
-            objective_function: Callable taking a Case (and optional kwargs)
-                and returning a scalar. Returning None marks the case failed.
-            objective_function_kwargs: Extra kwargs passed through to
-                `objective_function` on every call.
-            threshold: Optional MOO objective threshold (see Ax docs). Only
-                used by backends that support multi-objective Pareto fronts.
-            static_transform: Optional pure float→float transform applied to
-                each scalar output. Use for domain-driven re-expressions
-                (e.g. `math.log` for a log-distributed quantity). Not for
-                normalization — the backend handles that.
-        """
+    def __init__(self, name: str) -> None:
         self.name: str = name
         self.id: str = str(uuid4())
-        self.minimize: bool = minimize
-        self.threshold: Optional[float] = threshold
-        self.objective_function: Callable = objective_function
-        self.objective_function_kwargs: dict[str, Any] = dict(
-            objective_function_kwargs or {}
-        )
-        self.static_transform: Optional[Callable[[float], float]] = static_transform
-
         self._values: dict[Case, float] = {}
 
     def evaluate(self, case: Case, save_value: bool = True) -> Optional[float]:
-        """Evaluate the objective for a single case.
-
-        Returns the (optionally transformed) scalar, or None if the case
-        failed or the objective function returned None.
-        """
-        if case.success is False:
-            logging.warning("Case has been marked as failed: not evaluating objective")
-            return None
-
-        if self.objective_function_kwargs:
-            raw = self.objective_function(case, **self.objective_function_kwargs)
-        else:
-            raw = self.objective_function(case)
-
-        if raw is None:
-            logging.warning(f"Objective function returned a None for {case}")
-            logging.warning("Marking case as failed and not storing output!")
-            case.mark_failed()
-            return None
-
-        value = self.static_transform(raw) if self.static_transform else raw
-        value = coerce_objective_scalar(value, label=f"Objective '{self.name}' output")
-
-        if save_value:
-            self._values[case] = value
-
-        return value
+        raise NotImplementedError(
+            "_EvaluatedMetric subclasses must implement evaluate()"
+        )
 
     def batch_evaluate(
         self, cases: list[Case], save_values: bool = True
@@ -96,16 +35,251 @@ class Objective:
         return self._values.get(case)
 
     def metric_values_for_case(self, case: Case) -> dict[str, float]:
-        """Return {metric_name: value} contributed by this objective for `case`.
-
-        Used by the backend to build `raw_data` for `tell()`. An empty dict
-        signals "no value available" (case failed or not yet evaluated).
-        """
+        """Return {metric_name: value} contributed for `case`. Empty dict means
+        no value available (case failed or not yet evaluated)."""
         v = self.data_for_case(case)
         return {} if v is None else {self.name: v}
 
 
-class ScalarizedObjective:
+class _CallableMetric(_EvaluatedMetric):
+    """Metric whose value comes from calling a user-supplied function on the
+    Case. The single-function-call evaluator factors out the shared machinery
+    between Objective and Constraint. Not part of the public API.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        objective_function: Callable,
+        objective_function_kwargs: Optional[dict[str, Any]] = None,
+        static_transform: Optional[Callable[[float], float]] = None,
+    ) -> None:
+        super().__init__(name)
+        self.objective_function: Callable = objective_function
+        self.objective_function_kwargs: dict[str, Any] = dict(
+            objective_function_kwargs or {}
+        )
+        self.static_transform: Optional[Callable[[float], float]] = static_transform
+
+    def _value_label(self) -> str:
+        return f"Metric '{self.name}' output"
+
+    def evaluate(self, case: Case, save_value: bool = True) -> Optional[float]:
+        if case.success is False:
+            logging.warning("Case has been marked as failed: not evaluating metric")
+            return None
+
+        if self.objective_function_kwargs:
+            raw = self.objective_function(case, **self.objective_function_kwargs)
+        else:
+            raw = self.objective_function(case)
+
+        if raw is None:
+            logging.warning(f"Metric function returned a None for {case}")
+            logging.warning("Marking case as failed and not storing output!")
+            case.mark_failed()
+            return None
+
+        value = self.static_transform(raw) if self.static_transform else raw
+        value = coerce_objective_scalar(value, label=self._value_label())
+
+        if save_value:
+            self._values[case] = value
+
+        return value
+
+
+def _validate_bounds(gte: Optional[float], lte: Optional[float], context: str) -> None:
+    if gte is not None and not math.isfinite(gte):
+        raise ValueError(
+            f"{context}: gte={gte!r} must be a finite number. Use `None` to "
+            f"indicate 'no lower bound' — NaN and ±inf are not accepted."
+        )
+    if lte is not None and not math.isfinite(lte):
+        raise ValueError(
+            f"{context}: lte={lte!r} must be a finite number. Use `None` to "
+            f"indicate 'no upper bound' — NaN and ±inf are not accepted."
+        )
+    if gte is not None and lte is not None:
+        if gte > lte:
+            raise ValueError(
+                f"{context}: gte={gte} > lte={lte} defines an empty feasible range."
+            )
+        if gte == lte:
+            raise ValueError(
+                f"{context}: gte={gte} == lte={lte} defines a single-point "
+                f"feasible range, which has no meaning for a soft outcome "
+                f"constraint on a continuous GP surrogate. For a tight "
+                f"tolerance around X, use gte=X-eps, lte=X+eps."
+            )
+
+
+class Objective(_CallableMetric):
+    """A named optimization objective that evaluates a Case and returns a
+    scalar value.
+
+    Outcome standardization is the optimizer backend's job (Ax wraps every
+    metric in StandardizeY + BoTorch's Standardize). Don't add normalization
+    here. If your measurement is naturally non-linear (log-distributed drag,
+    say), pass `static_transform=math.log` — a pure float→float function,
+    applied per evaluation, no fitting, no state.
+
+    Objectives can carry a soft outcome bound via `gte`/`lte`. The bound
+    applies to the same measurement the objective optimizes (e.g. "minimize
+    drag, but also keep drag ≤ 0.05"). Under the hood this becomes a derived
+    tracking metric named ``{name}__bound`` with an `OutcomeConstraint`
+    pointing to it; Ax can't attach a constraint to an objective metric
+    directly, so the derived name is the workaround. For a bound on a metric
+    that isn't an optimization target, use a standalone `Constraint`.
+    """
+
+    BOUND_METRIC_SUFFIX = "__bound"
+
+    def __init__(
+        self,
+        name: str,
+        minimize: bool,
+        objective_function: Callable,
+        objective_function_kwargs: Optional[dict[str, Any]] = None,
+        threshold: Optional[float] = None,
+        static_transform: Optional[Callable[[float], float]] = None,
+        gte: Optional[float] = None,
+        lte: Optional[float] = None,
+    ) -> None:
+        """An optimization objective for an OpenFOAM simulation.
+
+        Args:
+            name: Identifier for the objective. Must be unique across all
+                metrics in the experiment (including those wrapped in a
+                ScalarizedObjective and any Constraints). If `gte` or `lte`
+                is set, the derived bound metric name ``{name}__bound`` must
+                also not collide with another registered metric.
+            minimize: True to minimize, False to maximize.
+            objective_function: Callable taking a Case (and optional kwargs)
+                and returning a scalar. Returning None marks the case failed.
+            objective_function_kwargs: Extra kwargs passed through to
+                `objective_function` on every call.
+            threshold: Optional MOO objective threshold (see Ax docs). Only
+                used by backends that support multi-objective Pareto fronts.
+            static_transform: Optional pure float→float transform applied to
+                each scalar output. Use for domain-driven re-expressions
+                (e.g. `math.log` for a log-distributed quantity). Not for
+                normalization — the backend handles that.
+            gte: Optional soft lower bound on this objective's value
+                (absolute, not relative). Steers the optimizer away from
+                regions where the bound is violated without hard-rejecting.
+            lte: Optional soft upper bound. Same semantics as `gte`.
+        """
+        _validate_bounds(gte, lte, context=f"Objective {name!r}")
+
+        super().__init__(
+            name=name,
+            objective_function=objective_function,
+            objective_function_kwargs=objective_function_kwargs,
+            static_transform=static_transform,
+        )
+        self.minimize: bool = minimize
+        self.threshold: Optional[float] = threshold
+        self.gte: Optional[float] = gte
+        self.lte: Optional[float] = lte
+
+    @property
+    def has_bounds(self) -> bool:
+        return self.gte is not None or self.lte is not None
+
+    @property
+    def bound_metric_name(self) -> str:
+        """Name of the derived tracking metric that carries this objective's
+        soft bound at the Ax layer. Only meaningful when `has_bounds` is True.
+        """
+        return f"{self.name}{self.BOUND_METRIC_SUFFIX}"
+
+    def _value_label(self) -> str:
+        return f"Objective '{self.name}' output"
+
+    def metric_values_for_case(self, case: Case) -> dict[str, float]:
+        """For a bounded Objective, emit both the objective metric and the
+        derived bound metric in the output dict. Ax expects raw_data to cover
+        every registered metric, including the tracking metric that holds the
+        bound.
+        """
+        v = self.data_for_case(case)
+        if v is None:
+            return {}
+        out = {self.name: v}
+        if self.has_bounds:
+            out[self.bound_metric_name] = v
+        return out
+
+
+class Constraint(_CallableMetric):
+    """A measurable quantity used to *steer* the optimizer rather than be
+    optimized for.
+
+    A Constraint registers a tracking metric with the backend (Ax: via
+    `experiment.add_tracking_metric`) and attaches a soft outcome constraint
+    to it. The optimizer evaluates the constraint metric on every case and is
+    discouraged from proposing regions where the bound is violated — but it
+    is not a hard reject; the backend's acquisition function applies a
+    penalty.
+
+    Use this when you have a measurement that should keep the optimizer in a
+    sensible region of the design space without it being one of the things
+    you're trying to push up or down (e.g. "pressure must stay ≥ 45.0 while
+    we minimize heat loss and heat flux").
+
+    Bounds are absolute. Ax's underlying `OutcomeConstraint` defaults to
+    relative bounds (interpreted as a percentage relative to a baseline arm),
+    which would silently change the meaning of every `gte`/`lte` users supply
+    here; flowboost intentionally inverts that default. Relative bounds are
+    not currently exposed — open an issue if you need them.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        objective_function: Callable,
+        gte: Optional[float] = None,
+        lte: Optional[float] = None,
+        objective_function_kwargs: Optional[dict[str, Any]] = None,
+        static_transform: Optional[Callable[[float], float]] = None,
+    ) -> None:
+        """A constraint-only metric.
+
+        Args:
+            name: Identifier for the constraint metric. Must be unique across
+                all metrics in the experiment.
+            objective_function: Callable taking a Case (and optional kwargs)
+                and returning the constraint metric's scalar value.
+            gte: Optional lower bound (absolute, not relative). At least one
+                of `gte` or `lte` must be supplied — a Constraint with no
+                bound has no effect.
+            lte: Optional upper bound (absolute, not relative).
+            objective_function_kwargs: Extra kwargs passed to the function.
+            static_transform: Optional pure float→float transform applied to
+                each output before the bound is checked.
+        """
+        if gte is None and lte is None:
+            raise ValueError(
+                f"Constraint {name!r} requires at least one of `gte` or `lte`. "
+                f"Without a bound, a constraint has no effect on the optimizer."
+            )
+        _validate_bounds(gte, lte, context=f"Constraint {name!r}")
+
+        super().__init__(
+            name=name,
+            objective_function=objective_function,
+            objective_function_kwargs=objective_function_kwargs,
+            static_transform=static_transform,
+        )
+        self.gte: Optional[float] = gte
+        self.lte: Optional[float] = lte
+
+    def _value_label(self) -> str:
+        return f"Constraint '{self.name}' output"
+
+
+class ScalarizedObjective(_EvaluatedMetric):
     """A weighted sum of multiple Objectives, optimized as a single scalar.
 
     Direction is encoded by signed weights: a negative weight flips the
@@ -172,7 +346,7 @@ class ScalarizedObjective:
                 "the threshold or use plain Objectives in MOO mode instead."
             )
 
-        self.name: str = name
+        super().__init__(name)
         self.minimize: bool = minimize
         self.objectives: list[Objective] = objectives
         self.weights: list[float] = (
@@ -229,8 +403,6 @@ class ScalarizedObjective:
         # Kept as a None attribute so call sites that read it don't break.
         self.threshold: Optional[float] = None
 
-        self._values: dict[Case, float] = {}
-
     def evaluate(self, case: Case, save_value: bool = True) -> Optional[float]:
         """Evaluate every inner objective and return the signed weighted sum.
 
@@ -258,28 +430,24 @@ class ScalarizedObjective:
 
         return scalar
 
-    def batch_evaluate(
-        self, cases: list[Case], save_values: bool = True
-    ) -> list[Optional[float]]:
-        return [self.evaluate(case=case, save_value=save_values) for case in cases]
-
-    def data_for_case(self, case: Case) -> Optional[float]:
-        """Return the cached scalarized value for a case."""
-        return self._values.get(case)
-
     def metric_values_for_case(self, case: Case) -> dict[str, float]:
-        """Return {inner_metric_name: value} for each inner objective.
+        """Return per-inner metric values for each inner objective, including
+        the derived bound alias ``{name}__bound`` for any inner carrying
+        `gte`/`lte`. Delegates to each inner's own `metric_values_for_case`
+        so the emit logic for bounds lives in one place.
 
         These are the per-metric values backends with native scalarization
-        (e.g. Ax) expect — Ax does the weighted sum itself at the acquisition
-        step.
+        (e.g. Ax) expect: Ax does the weighted sum itself at the acquisition
+        step, and reads bound tracking metrics separately for any
+        OutcomeConstraints. Overrides the base implementation, which would
+        return the scalar under the ScalarizedObjective's own name.
         """
         out: dict[str, float] = {}
         for obj in self.objectives:
-            v = obj.data_for_case(case)
-            if v is None:
+            inner_values = obj.metric_values_for_case(case)
+            if not inner_values:
                 return {}
-            out[obj.name] = v
+            out.update(inner_values)
         return out
 
 

--- a/flowboost/session/session.py
+++ b/flowboost/session/session.py
@@ -4,7 +4,7 @@ import logging
 import shutil
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Literal, Optional, Union
+from typing import Any, Iterable, Literal, Optional, Union
 
 from flowboost.config import config
 from flowboost.manager.manager import JobV2, Manager
@@ -12,6 +12,7 @@ from flowboost.openfoam.case import Case, path_is_foam_dir, unique_id
 from flowboost.openfoam.data import _BACKENDS as _DATA_BACKENDS
 from flowboost.openfoam.dictionary import DictionaryLink, DictionaryReader, Entry
 from flowboost.openfoam.types import FOAMType
+from flowboost.optimizer.objectives import Constraint, Objective, ScalarizedObjective
 from flowboost.optimizer.acquisition_offload import OFFLOAD_SCRIPT
 from flowboost.optimizer.backend import (
     Backend,
@@ -19,6 +20,8 @@ from flowboost.optimizer.backend import (
     OptimizationComplete,
 )
 from flowboost.optimizer.search_space import Dimension
+
+OptimizationObjective = Union[Objective, ScalarizedObjective]
 
 
 class Session:
@@ -59,8 +62,10 @@ class Session:
                 session restarts. Note: this mutates ``torch``'s global RNG \
                 state, which may affect user code that depends on it in the \
                 same process. Defaults to None (non-deterministic).
-            max_evaluations (Optional[int], optional): Maximum number of evaluations \
-                before stopping optimization. Defaults to None (no limit).
+            max_evaluations (Optional[int], optional): Maximum number of attempted \
+                case evaluations before stopping optimization. Completed failed \
+                cases and pending submitted cases both count against this cap. \
+                Defaults to None (no limit).
             target_value (Optional[float], optional): Target objective value to reach. \
                 Optimization stops when this value is achieved. Defaults to None.
             target_objective (Optional[str], optional): Name of objective to check \
@@ -109,6 +114,78 @@ class Session:
             logging.info(f"Session created ({self.data_dir})")
             self.persist()
 
+    def set_search_space(
+        self, dimensions: Union[Dimension, Iterable[Dimension]]
+    ) -> "Session":
+        """Register the case parameters the optimizer is allowed to vary.
+
+        Each Dimension should point at an OpenFOAM dictionary entry on the
+        template case. Accepts either a single Dimension or an iterable of
+        Dimensions. Returns the Session so calls can be chained.
+        """
+        if isinstance(dimensions, Dimension):
+            dimensions = [dimensions]
+        self.backend.set_search_space(list(dimensions))
+        return self
+
+    def set_objectives(
+        self,
+        objectives: Union[OptimizationObjective, Iterable[OptimizationObjective]],
+    ) -> "Session":
+        """Register the quantities the optimizer should optimize.
+
+        Accepts a single Objective, a single ScalarizedObjective, or an
+        iterable of Objectives. Constraints should be registered separately
+        with set_constraints(); they are tracked feasibility metrics, not
+        optimization targets. Returns the Session so calls can be chained.
+        """
+        if isinstance(objectives, (Objective, ScalarizedObjective)):
+            objectives = [objectives]
+        self.backend.set_objectives(list(objectives))
+        return self
+
+    def set_constraints(
+        self, constraints: Union[Constraint, Iterable[Constraint]]
+    ) -> "Session":
+        """Register feasibility bounds that guide optimizer suggestions.
+
+        Constraints are evaluated alongside objectives and passed to the
+        backend as outcome constraints, but they are not optimized directly.
+        Accepts either a single Constraint or an iterable of Constraints.
+        Returns the Session so calls can be chained.
+        """
+        self.backend.set_constraints(constraints)
+        return self
+
+    def configure_optimization(
+        self,
+        *,
+        objectives: Union[OptimizationObjective, Iterable[OptimizationObjective]],
+        search_space: Union[Dimension, Iterable[Dimension]],
+        constraints: Optional[Union[Constraint, Iterable[Constraint]]] = None,
+    ) -> "Session":
+        """Configure the optimizer's public problem definition in one call.
+
+        Use this for the common setup step after defining Objectives,
+        optional Constraints, and search-space Dimensions:
+
+            session.configure_optimization(
+                objectives=[lift, drag],
+                constraints=[pressure],
+                search_space=[angle, speed],
+            )
+
+        The method delegates to set_objectives(), set_constraints(), and
+        set_search_space() so their validation and backend behavior stay
+        identical. Backend-specific knobs such as initialization_trials remain
+        available through session.backend.
+        """
+        self.set_objectives(objectives)
+        if constraints is not None:
+            self.set_constraints(constraints)
+        self.set_search_space(search_space)
+        return self
+
     def get_all_cases(self, include_failed: bool = True) -> list[Case]:
         """
         Get finished and pending cases in one list.
@@ -120,6 +197,20 @@ class Session:
             self.get_finished_cases(include_failed=include_failed)
             + self.get_pending_cases()
         )
+
+    def _remaining_evaluation_budget(self) -> Optional[int]:
+        """Return how many additional case submissions fit in max_evaluations.
+
+        max_evaluations is an attempt budget: failed completed cases and
+        pending submitted cases both consume it.
+        """
+        if self.max_evaluations is None:
+            return None
+
+        committed_cases = len(self.get_finished_cases(include_failed=True)) + len(
+            self.get_pending_cases()
+        )
+        return self.max_evaluations - committed_cases
 
     def get_finished_cases(
         self, include_failed: bool = False, batch_process: bool = False
@@ -246,7 +337,7 @@ class Session:
                     )
                     continue
 
-                Case(
+                Case.try_restoring(
                     case_dest, data_backend=self.dataframe_format
                 ).post_evaluation_update(job.to_dict())
                 if not self.job_manager.finalize_job(job):
@@ -260,6 +351,34 @@ class Session:
                 self._write_designs_log()
                 logging.info("Optimization complete!")
                 return
+
+            remaining_budget = self._remaining_evaluation_budget()
+            if remaining_budget is not None:
+                if remaining_budget <= 0:
+                    if self.get_pending_cases():
+                        logging.info(
+                            "Maximum evaluation budget is committed; "
+                            "waiting for pending jobs"
+                        )
+                        continue
+
+                    logging.info(
+                        "Maximum evaluation budget is committed - stopping optimization"
+                    )
+                    self._write_designs_log()
+                    logging.info("Optimization complete!")
+                    return
+
+                if free_slots > remaining_budget:
+                    logging.info(
+                        f"Capping new cases to remaining evaluation budget: "
+                        f"{remaining_budget}/{self.max_evaluations}"
+                    )
+                    free_slots = remaining_budget
+
+            if free_slots <= 0:
+                logging.info("No free job slots available")
+                continue
 
             logging.info("Entering optimizer loop")
             try:
@@ -806,7 +925,7 @@ class Session:
             bool: True if optimization should stop, False otherwise
         """
         finished_cases = self.get_finished_cases(
-            include_failed=False,
+            include_failed=True,
             batch_process=self.target_value is not None,
         )
 
@@ -824,6 +943,12 @@ class Session:
             if not self.backend.objectives:
                 logging.warning("No objectives configured - cannot check target value")
                 return False
+
+            finished_cases = [
+                case
+                for case in finished_cases
+                if (case.success or case.success is None)
+            ]
 
             # Determine which objective to check
             if self.target_objective:
@@ -887,9 +1012,9 @@ class Session:
             by_objective (Optional[str]): Name of objective to rank by. If None, \
                 uses the first objective. Defaults to None.
         """
-        # Get finished and successful cases
+        # Use batch_process=True so inner ScalarizedObjective values get cached
         finished_cases = self.get_finished_cases(
-            include_failed=False, batch_process=False
+            include_failed=False, batch_process=True
         )
 
         if not finished_cases:
@@ -911,58 +1036,106 @@ class Session:
         else:
             objective = self.backend.objectives[0]
 
-        # Extract objective values for all cases from metadata
+        # Always rank by the top-level objective (including scalarized sum)
+        rank_objective = objective
+        is_scalarized = isinstance(objective, ScalarizedObjective)
+
+        # Columns: if scalarized, show [scalarized, inner..., other objectives]
+        # if not scalarized, show [objective, other objectives]
+        if is_scalarized:
+            inner_objectives = list(objective.objectives)
+            display_objectives = [objective] + inner_objectives
+        else:
+            display_objectives = [objective]
+
+        display_names = {o.name for o in display_objectives}
+        other_objectives = [
+            obj
+            for obj in self.backend.objectives
+            if obj.name not in display_names
+            and not isinstance(obj, ScalarizedObjective)
+        ]
+        all_display_cols = display_objectives + other_objectives
+
+        def _get_obj_value(case: Case, obj, metadata: dict) -> Optional[float]:
+            """Try metadata first, then fall back to cached data_for_case value."""
+            obj_outputs = metadata.get("objective-outputs", {})
+            val = obj_outputs.get(obj.name, {}).get("value")
+            if val is None:
+                val = obj.data_for_case(case)
+            return val
+
+        # Extract ranking values for all cases
         case_scores = []
         for case in finished_cases:
             metadata = case.read_metadata()
             if not metadata:
                 continue
 
-            obj_outputs = metadata.get("objective-outputs", {})
-            value = obj_outputs.get(objective.name, {}).get("value")
-
+            value = _get_obj_value(case, rank_objective, metadata)
             if value is not None:
                 gen_index = metadata.get("generation_index", "99999.99")
                 case_scores.append((case, value, gen_index))
 
         if not case_scores:
-            print(f"No valid objective values found for '{objective.name}'")
+            print(f"No valid objective values found for '{rank_objective.name}'")
             return
 
+        constraints = getattr(self.backend, "constraints", []) or []
+
         if n is None:
-            # Show all in submission order
-            case_scores.sort(key=lambda x: x[2])  # Sort by generation_index
+            case_scores.sort(key=lambda x: x[2])
             display_cases = case_scores
-            header = f"=== All Designs in Submission Order (by '{objective.name}') ==="
+            header = "=== All Designs in Submission Order ==="
         else:
-            reverse = not objective.minimize  # Higher is better if maximizing
+            reverse = not rank_objective.minimize
             case_scores.sort(key=lambda x: x[1], reverse=reverse)
             display_cases = case_scores[: min(n, len(case_scores))]
-            header = f"=== Top {len(display_cases)} Designs (by '{objective.name}') ==="
-
-        other_objectives = [
-            obj for obj in self.backend.objectives if obj.name != objective.name
-        ]
+            header = f"=== Top {len(display_cases)} Designs (ranked by '{rank_objective.name}') ==="
 
         COL_RANK = 6
         COL_NAME = 35
         COL_OBJ = 18
+        COL_CON = 18
         COL_PARAMS = 30
-        n_obj_cols = 1 + len(other_objectives)
+        n_obj_cols = len(all_display_cols)
+        n_con_cols = len(constraints)
+
+        def _obj_header_label(obj) -> str:
+            # Mark inner objectives visually with indentation
+            if is_scalarized and obj.name in {o.name for o in inner_objectives}:
+                return f"  {obj.name}".ljust(COL_OBJ)
+            return obj.name.ljust(COL_OBJ)
+
+        def _con_header_label(con: Constraint) -> str:
+            bounds = []
+            if con.gte is not None:
+                bounds.append(f">={con.gte}")
+            if con.lte is not None:
+                bounds.append(f"<={con.lte}")
+            label = f"{con.name}[{','.join(bounds)}]" if bounds else con.name
+            return label.ljust(COL_CON)
 
         print(f"\n{header}")
-        obj_header = f"{objective.name:<{COL_OBJ}}" + "".join(
-            f"{obj.name:<{COL_OBJ}}" for obj in other_objectives
+        obj_header = "".join(_obj_header_label(obj) for obj in all_display_cols)
+        con_header = "".join(_con_header_label(con) for con in constraints)
+        print(
+            f"{'Rank':<{COL_RANK}} {'Case Name':<{COL_NAME}} {obj_header}{con_header} {'Parameters'}"
         )
         print(
-            f"{'Rank':<{COL_RANK}} {'Case Name':<{COL_NAME}} {obj_header} {'Parameters'}"
+            "-"
+            * (
+                COL_RANK
+                + COL_NAME
+                + COL_OBJ * n_obj_cols
+                + COL_CON * n_con_cols
+                + COL_PARAMS
+            )
         )
-        print("-" * (COL_RANK + COL_NAME + COL_OBJ * n_obj_cols + COL_PARAMS))
 
         for rank, (case, value, gen_index) in enumerate(display_cases, 1):
             metadata = case.read_metadata()
 
-            # Get parameter values
             params = []
             if metadata and "optimizer-suggestion" in metadata:
                 opt_sugg = metadata["optimizer-suggestion"]
@@ -974,19 +1147,31 @@ class Session:
                 ]
             params_str = ", ".join(params) if params else "N/A"
 
-            obj_values_str = f"{value:<18.6f}"
-
-            # Other objectives' values
+            obj_values_str = ""
+            con_values_str = ""
             if metadata:
-                obj_outputs = metadata.get("objective-outputs", {})
-                for obj in other_objectives:
-                    other_val = obj_outputs.get(obj.name, {}).get("value")
-                    if other_val is not None:
-                        obj_values_str += f"{other_val:<18.6f}"
-                    else:
-                        obj_values_str += f"{'N/A':<18}"
+                for obj in all_display_cols:
+                    col_val = _get_obj_value(case, obj, metadata)
+                    obj_values_str += (
+                        f"{col_val:<{COL_OBJ}.6f}"
+                        if col_val is not None
+                        else f"{'N/A':<{COL_OBJ}}"
+                    )
 
-            print(f"{rank:<6} {case.name:<35} {obj_values_str} {params_str}")
+                con_outputs = metadata.get("constraint-outputs", {})
+                for con in constraints:
+                    col_val = con_outputs.get(con.name, {}).get("value")
+                    if col_val is None:
+                        col_val = con.data_for_case(case)
+                    con_values_str += (
+                        f"{col_val:<{COL_CON}.6f}"
+                        if col_val is not None
+                        else f"{'N/A':<{COL_CON}}"
+                    )
+
+            print(
+                f"{rank:<6} {case.name:<35} {obj_values_str}{con_values_str} {params_str}"
+            )
 
         print()
 
@@ -994,7 +1179,7 @@ class Session:
         """
         Writes a JSON file to the session data directory containing all
         completed designs in chronological (submission) order, with their
-        parameters and raw objective values.
+        parameters, raw objective values, and constraint values.
 
         The file is overwritten on each call, always reflecting the full
         current state.
@@ -1002,14 +1187,31 @@ class Session:
         Args:
             fname (str): Output filename. Defaults to 'designs.json'.
         """
+        # batch_process=True so inner objective values get cached on the objective objects
         finished_cases = self.get_finished_cases(
-            include_failed=False, batch_process=False
+            include_failed=False, batch_process=True
         )
 
         if not finished_cases:
             return
 
         designs = []
+        constraints = getattr(self.backend, "constraints", []) or []
+
+        def objective_log_entry(obj_data: dict[str, Any]) -> dict[str, Any]:
+            """Keep the designs log aligned with objective-outputs metadata."""
+            return {
+                key: obj_data[key]
+                for key in (
+                    "value",
+                    "minimize",
+                    "gte",
+                    "lte",
+                    "components",
+                    "component_bounds",
+                )
+                if key in obj_data
+            }
 
         for case in finished_cases:
             metadata = case.read_metadata()
@@ -1026,10 +1228,47 @@ class Session:
             objectives = {}
             if "objective-outputs" in metadata:
                 for obj_name, obj_data in metadata["objective-outputs"].items():
-                    objectives[obj_name] = {
-                        "value": obj_data.get("value"),
-                        "minimize": obj_data.get("minimize"),
-                    }
+                    objectives[obj_name] = objective_log_entry(obj_data)
+
+            # For ScalarizedObjectives, annotate with is_scalarized + components
+            # Inner values come from the objective cache (populated by batch_process above)
+            for obj in self.backend.objectives:
+                if isinstance(obj, ScalarizedObjective):
+                    objectives[obj.name] = objectives.get(obj.name, {})
+                    objectives[obj.name]["is_scalarized"] = True
+                    metadata_components = objectives[obj.name].get("components", {})
+                    objectives[obj.name]["components"] = {}
+                    for inner_obj in obj.objectives:
+                        # First try metadata (in case backend stores inner values there)
+                        inner_val = objectives.get(inner_obj.name)
+                        if inner_val is not None:
+                            objectives[obj.name]["components"][inner_obj.name] = (
+                                inner_val
+                            )
+                        elif inner_obj.name in metadata_components:
+                            objectives[obj.name]["components"][inner_obj.name] = {
+                                "value": metadata_components[inner_obj.name],
+                                "minimize": inner_obj.minimize,
+                            }
+                        else:
+                            # Fall back to cached value from batch_process evaluation
+                            cached = inner_obj.data_for_case(case)
+                            if cached is not None:
+                                objectives[obj.name]["components"][inner_obj.name] = {
+                                    "value": cached,
+                                    "minimize": inner_obj.minimize,
+                                }
+
+            # Constraint values
+            constraints_out = {}
+            con_outputs = metadata.get("constraint-outputs", {})
+            for con in constraints:
+                con_data = con_outputs.get(con.name, {})
+                constraints_out[con.name] = {
+                    "value": con_data.get("value"),
+                    "gte": con.gte,
+                    "lte": con.lte,
+                }
 
             designs.append(
                 {
@@ -1038,6 +1277,7 @@ class Session:
                     "created_at": str(metadata.get("created_at", "")),
                     "parameters": params,
                     "objectives": objectives,
+                    "constraints": constraints_out,
                 }
             )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flowboost"
-version = "0.2.9"
+version = "0.3.0"
 description = "Multi-objective Bayesian optimization library for OpenFOAM"
 license = "Apache-2.0"
 license-files = ["LICENSE"]

--- a/tests/flowboost/optimizer/conftest.py
+++ b/tests/flowboost/optimizer/conftest.py
@@ -4,6 +4,16 @@ from typing import Callable, Union
 import pytest
 
 from flowboost.openfoam.case import Case
+from flowboost.openfoam.dictionary import DictionaryLink
+from flowboost.optimizer.search_space import Dimension
+
+
+@pytest.fixture
+def case(tmp_path: Path) -> Case:
+    """A bare Case under tmp_path. No metadata, no parameters."""
+    d = tmp_path / "test_case"
+    d.mkdir()
+    return Case(d)
 
 
 @pytest.fixture
@@ -27,5 +37,18 @@ def make_suggestion_case() -> Callable[[Path, str, dict], Case]:
             entry_header="optimizer-suggestion",
         )
         return case
+
+    return _make
+
+
+@pytest.fixture
+def make_dim() -> Callable[[str], Dimension]:
+    """Factory for a generic 0..1 range Dimension. Used by backend/objective
+    unit tests that need a search-space dimension but don't care about the
+    underlying dictionary entry."""
+
+    def _make(name: str = "dim") -> Dimension:
+        link = DictionaryLink("constant/foo").entry("bar")
+        return Dimension.range(name=name, link=link, lower=0.0, upper=1.0)
 
     return _make

--- a/tests/flowboost/optimizer/test_backend.py
+++ b/tests/flowboost/optimizer/test_backend.py
@@ -10,7 +10,7 @@ from flowboost.openfoam.case import Case
 from flowboost.openfoam.dictionary import DictionaryLink
 from flowboost.optimizer.backend import OptimizationComplete
 from flowboost.optimizer.interfaces.Ax import AxBackend
-from flowboost.optimizer.objectives import Objective, ScalarizedObjective
+from flowboost.optimizer.objectives import Constraint, Objective, ScalarizedObjective
 from flowboost.optimizer.search_space import Dimension
 
 
@@ -33,16 +33,6 @@ def Ax_backend() -> AxBackend:
     # Add objective
     objective = Objective(
         name="test_objective", minimize=True, objective_function=lambda x: 1
-    )
-
-    # Define something to modify
-    dict_link = DictionaryLink("constant/chemistryProperties").entry(
-        "tabulation/tolerance"
-    )
-
-    # Add dimension for the dictionary entry
-    dim = Dimension.range(
-        name="test_dim", link=dict_link, lower=1e-5, upper=1e-1, log_scale=True
     )
 
     # Define something to modify
@@ -135,12 +125,12 @@ def test_tell_on_unevaluated_case_raises_clear_error(tmp_path):
     """Calling tell() with a case that hasn't been batch-processed used to
     blow up with 'output None for case ...' from deep inside Case; it should
     now point the caller at batch_process / get_finished_cases(batch_process=True)."""
-    unevaluated = _make_case(tmp_path, "unevaluated", value=0.5)
-    backend, _ = _make_simple_backend(unevaluated)
-    other = _make_case(tmp_path, "other", value=0.25)
+    seed_case = _make_case(tmp_path, "seed", value=0.5)
+    backend, _ = _make_simple_backend(seed_case)
+    unevaluated = _make_case(tmp_path, "unevaluated", value=0.25)
 
     with pytest.raises(ValueError, match="has not been evaluated"):
-        backend.tell([other])
+        backend.tell([unevaluated])
 
 
 @pytest.mark.slow
@@ -464,6 +454,98 @@ def test_offloaded_acquisition_accepts_duplicate_parameterizations(tmp_path):
     )
     output_path = tmp_path / "duplicate_acquisition_result.json"
 
+    AxBackend.offloaded_acquisition(
+        model_snapshot=model_snapshot,
+        data_snapshot=data_snapshot,
+        num_trials=1,
+        output_path=output_path,
+    )
+
+    result = json.loads(output_path.read_text())
+    assert result["optimizer"] == "AxBackend"
+    assert result["status_finished"] is False
+    assert len(result["parametrizations"]) == 1
+
+
+def test_offloaded_acquisition_round_trip_with_scalarized_objective_and_constraint(
+    tmp_path,
+):
+    case = _make_case(tmp_path, "scalarized-constrained", value=0.5)
+
+    component_a = Objective(
+        name="component_a",
+        minimize=True,
+        objective_function=lambda c: float(
+            c.read_metadata()["optimizer-suggestion"]["test_dim"]["value"]
+        ),
+    )
+    component_b = Objective(
+        name="component_b",
+        minimize=True,
+        objective_function=lambda c: (
+            2.0 * float(c.read_metadata()["optimizer-suggestion"]["test_dim"]["value"])
+        ),
+    )
+    scalarized = ScalarizedObjective(
+        name="scalarized",
+        minimize=True,
+        objectives=[component_a, component_b],
+        weights=[0.5, 0.5],
+    )
+    pressure = Constraint(
+        name="pressure",
+        objective_function=lambda c: (
+            1.0 - float(c.read_metadata()["optimizer-suggestion"]["test_dim"]["value"])
+        ),
+        gte=0.0,
+    )
+
+    backend = AxBackend()
+    backend.offload_acquisition = True
+    backend.random_seed = 0
+    backend.initialization_trials = 1
+    backend.set_search_space(
+        [
+            Dimension.range(
+                name="test_dim",
+                link=DictionaryLink("constant/chemistryProperties").entry(
+                    "tabulation/tolerance"
+                ),
+                lower=0.0,
+                upper=1.0,
+            )
+        ]
+    )
+    backend.set_objectives(scalarized)
+    backend.set_constraints([pressure])
+    backend.initialize()
+
+    scalarized.batch_evaluate([case])
+    pressure.batch_evaluate([case])
+
+    model_snapshot, data_snapshot = backend.prepare_for_acquisition_offload(
+        [case], [], tmp_path
+    )
+    snapshot_data = json.loads(data_snapshot.read_text())
+    objectives = snapshot_data["finished_cases"][case.name]["objectives"]
+    assert objectives == {
+        "component_a": 0.5,
+        "component_b": 1.0,
+        "pressure": 0.5,
+    }
+
+    restored = AxBackend.restore_from_state_snapshot(model_snapshot)
+    opt_cfg = restored.client.experiment.optimization_config
+    assert {metric.name for metric in opt_cfg.objective.metrics} == {
+        "component_a",
+        "component_b",
+    }
+    assert {
+        (oc.metric.name, oc.op.name, oc.bound, oc.relative)
+        for oc in opt_cfg.outcome_constraints
+    } == {("pressure", "GEQ", 0.0, False)}
+
+    output_path = tmp_path / "scalarized_constrained_acquisition_result.json"
     AxBackend.offloaded_acquisition(
         model_snapshot=model_snapshot,
         data_snapshot=data_snapshot,

--- a/tests/flowboost/optimizer/test_backend_unit.py
+++ b/tests/flowboost/optimizer/test_backend_unit.py
@@ -13,15 +13,10 @@ def _make_objective(name="obj"):
     return Objective(name=name, minimize=True, objective_function=lambda c: 1.0)
 
 
-def _make_dim(name="dim"):
-    link = DictionaryLink("constant/foo").entry("bar")
-    return Dimension.range(name=name, link=link, lower=0.0, upper=1.0)
-
-
 class TestVerifyConfiguration:
-    def test_no_objectives_raises(self):
+    def test_no_objectives_raises(self, make_dim):
         backend = AxBackend()
-        backend.set_search_space([_make_dim()])
+        backend.set_search_space([make_dim()])
         with pytest.raises(ValueError, match="not defined"):
             backend._verify_configuration()
 
@@ -31,23 +26,23 @@ class TestVerifyConfiguration:
         with pytest.raises(ValueError, match="not defined"):
             backend._verify_configuration()
 
-    def test_duplicate_objective_names_raises(self):
+    def test_duplicate_objective_names_raises(self, make_dim):
         backend = AxBackend()
-        backend.set_search_space([_make_dim()])
+        backend.set_search_space([make_dim()])
         backend.set_objectives([_make_objective("dup"), _make_objective("dup")])
         with pytest.raises(ValueError, match="unique"):
             backend._verify_configuration()
 
-    def test_duplicate_dim_names_raises(self):
+    def test_duplicate_dim_names_raises(self, make_dim):
         backend = AxBackend()
         backend.set_objectives([_make_objective()])
-        backend.set_search_space([_make_dim("dup"), _make_dim("dup")])
+        backend.set_search_space([make_dim("dup"), make_dim("dup")])
         with pytest.raises(ValueError, match="unique"):
             backend._verify_configuration()
 
-    def test_valid_config_passes(self):
+    def test_valid_config_passes(self, make_dim):
         backend = AxBackend()
-        backend.set_search_space([_make_dim("x")])
+        backend.set_search_space([make_dim("x")])
         backend.set_objectives([_make_objective("y")])
         backend._verify_configuration()  # should not raise
 
@@ -65,15 +60,15 @@ class TestNameLookups:
         with pytest.raises(ValueError, match="not found"):
             backend._objective_name_to_objective("missing")
 
-    def test_dim_lookup(self):
+    def test_dim_lookup(self, make_dim):
         backend = AxBackend()
-        dim = _make_dim("target")
+        dim = make_dim("target")
         backend.set_search_space([dim])
         assert backend._dim_name_to_dimension("target") is dim
 
-    def test_dim_lookup_missing_raises(self):
+    def test_dim_lookup_missing_raises(self, make_dim):
         backend = AxBackend()
-        backend.set_search_space([_make_dim("other")])
+        backend.set_search_space([make_dim("other")])
         with pytest.raises(ValueError, match="not found"):
             backend._dim_name_to_dimension("missing")
 
@@ -113,10 +108,10 @@ class TestBackendCreate:
 
 
 class TestPostProcessSuggestionParametrizations:
-    def test_maps_str_keys_to_dimensions(self):
+    def test_maps_str_keys_to_dimensions(self, make_dim):
         backend = AxBackend()
-        dim_a = _make_dim("alpha")
-        dim_b = _make_dim("beta")
+        dim_a = make_dim("alpha")
+        dim_b = make_dim("beta")
         backend.set_search_space([dim_a, dim_b])
 
         parametrizations = {0: {"alpha": 1.0, "beta": 2.0}}
@@ -126,16 +121,16 @@ class TestPostProcessSuggestionParametrizations:
         assert result[0][dim_a] == 1.0
         assert result[0][dim_b] == 2.0
 
-    def test_unknown_key_raises(self):
+    def test_unknown_key_raises(self, make_dim):
         backend = AxBackend()
-        backend.set_search_space([_make_dim("known")])
+        backend.set_search_space([make_dim("known")])
 
         with pytest.raises(ValueError, match="not found"):
             backend._post_process_suggestion_parametrizations({0: {"unknown_dim": 1.0}})
 
-    def test_empty_parametrizations(self):
+    def test_empty_parametrizations(self, make_dim):
         backend = AxBackend()
-        backend.set_search_space([_make_dim()])
+        backend.set_search_space([make_dim()])
         assert backend._post_process_suggestion_parametrizations({}) == []
 
 
@@ -159,9 +154,9 @@ class TestDimToAxEdgeCases:
 
 
 class TestBatchProcessAllFailed:
-    def test_all_cases_failed_returns_empty(self, tmp_path):
+    def test_all_cases_failed_returns_empty(self, tmp_path, make_dim):
         backend = AxBackend()
-        backend.set_search_space([_make_dim()])
+        backend.set_search_space([make_dim()])
         obj = Objective("test", minimize=True, objective_function=lambda c: None)
         backend.set_objectives([obj])
 
@@ -178,9 +173,9 @@ class TestBatchProcessAllFailed:
 
 
 class TestBatchProcessSuccessStateSemantics:
-    def test_success_none_case_is_processed_and_persisted(self, tmp_path):
+    def test_success_none_case_is_processed_and_persisted(self, tmp_path, make_dim):
         backend = AxBackend()
-        backend.set_search_space([_make_dim()])
+        backend.set_search_space([make_dim()])
         backend.set_objectives([_make_objective("score")])
 
         case_dir = tmp_path / "case"
@@ -194,9 +189,11 @@ class TestBatchProcessSuccessStateSemantics:
         assert metadata is not None
         assert metadata["objective-outputs"]["score"]["value"] == 1.0
 
-    def test_success_none_case_is_processed_for_scalarized_objective(self, tmp_path):
+    def test_success_none_case_is_processed_for_scalarized_objective(
+        self, tmp_path, make_dim
+    ):
         backend = AxBackend()
-        backend.set_search_space([_make_dim()])
+        backend.set_search_space([make_dim()])
         backend.set_objectives(
             [
                 ScalarizedObjective(

--- a/tests/flowboost/optimizer/test_constraints.py
+++ b/tests/flowboost/optimizer/test_constraints.py
@@ -1,0 +1,1415 @@
+"""Tests for the Constraint primitive.
+
+Covers construction-time validation, evaluation reuse from the shared
+_CallableMetric base, and the end-to-end Ax integration that fixes the
+silent-failure bug previously triggered by the old `set_outcome_constraints`
+string DSL when a constraint metric wasn't registered as an objective.
+"""
+
+import json
+import logging
+
+import pytest
+
+from flowboost.openfoam.case import Case
+from flowboost.openfoam.dictionary import DictionaryLink
+from flowboost.optimizer.interfaces.Ax import AxBackend
+from flowboost.optimizer.objectives import Constraint, Objective, ScalarizedObjective
+from flowboost.optimizer.search_space import Dimension
+
+
+class TestConstraintConstruction:
+    def test_requires_at_least_one_bound(self):
+        with pytest.raises(ValueError, match="at least one of"):
+            Constraint(name="c", objective_function=lambda c: 1.0)
+
+    def test_accepts_gte_only(self):
+        c = Constraint(name="c", objective_function=lambda c: 1.0, gte=0.5)
+        assert c.gte == 0.5
+        assert c.lte is None
+
+    def test_accepts_lte_only(self):
+        c = Constraint(name="c", objective_function=lambda c: 1.0, lte=10.0)
+        assert c.gte is None
+        assert c.lte == 10.0
+
+    def test_accepts_both_bounds(self):
+        c = Constraint(name="c", objective_function=lambda c: 1.0, gte=0.0, lte=1.0)
+        assert (c.gte, c.lte) == (0.0, 1.0)
+
+    def test_rejects_empty_feasible_range(self):
+        with pytest.raises(ValueError, match="empty feasible range"):
+            Constraint(name="c", objective_function=lambda c: 1.0, gte=10.0, lte=5.0)
+
+    def test_rejects_single_point_feasible_range(self):
+        with pytest.raises(ValueError, match="single-point feasible range"):
+            Constraint(name="c", objective_function=lambda c: 1.0, gte=5.0, lte=5.0)
+
+    @pytest.mark.parametrize(
+        "bad_value",
+        [float("nan"), float("inf"), float("-inf")],
+        ids=["nan", "pos_inf", "neg_inf"],
+    )
+    def test_rejects_non_finite_gte(self, bad_value):
+        with pytest.raises(ValueError, match="must be a finite number"):
+            Constraint(name="c", objective_function=lambda c: 1.0, gte=bad_value)
+
+    @pytest.mark.parametrize(
+        "bad_value",
+        [float("nan"), float("inf"), float("-inf")],
+        ids=["nan", "pos_inf", "neg_inf"],
+    )
+    def test_rejects_non_finite_lte(self, bad_value):
+        with pytest.raises(ValueError, match="must be a finite number"):
+            Constraint(name="c", objective_function=lambda c: 1.0, lte=bad_value)
+
+
+class TestConstraintEvaluation:
+    def test_evaluate_caches_value(self, case):
+        c = Constraint(name="c", objective_function=lambda case: 7.5, gte=0.0)
+        assert c.evaluate(case) == 7.5
+        assert c.data_for_case(case) == 7.5
+
+    def test_static_transform_applied(self, case):
+        import math
+
+        c = Constraint(
+            name="c",
+            objective_function=lambda case: math.e,
+            gte=0.0,
+            static_transform=math.log,
+        )
+        assert c.evaluate(case) == pytest.approx(1.0)
+
+    def test_metric_values_for_case(self, case):
+        c = Constraint(name="pressure", objective_function=lambda case: 50.0, gte=45.0)
+        c.evaluate(case)
+        assert c.metric_values_for_case(case) == {"pressure": 50.0}
+
+    def test_failed_case_returns_none(self, tmp_path):
+        d = tmp_path / "failed"
+        d.mkdir()
+        case = Case(d)
+        case.success = False
+        c = Constraint(name="c", objective_function=lambda case: 1.0, gte=0.0)
+        assert c.evaluate(case) is None
+
+
+class TestAxBackendConstraintIntegration:
+    """End-to-end tests that the silent-failure pattern from issue #24 is
+    fixed: a constraint metric registered via set_constraints gets its values
+    sent to Ax and trials complete cleanly (no 'missing required metric'
+    warning, no spurious failure marking)."""
+
+    def _read_value(self, case, key):
+        return float(case.read_metadata()["optimizer-suggestion"][key]["value"])
+
+    def test_constraint_metric_registered_as_tracking_metric(self, make_dim):
+        backend = AxBackend()
+        backend.set_search_space([make_dim()])
+        backend.set_objectives(
+            [Objective(name="score", minimize=True, objective_function=lambda c: 1.0)]
+        )
+        backend.set_constraints(
+            [Constraint(name="pressure", objective_function=lambda c: 50.0, gte=45.0)]
+        )
+        backend.initialize()
+
+        # Both objective and constraint metrics live in experiment.metrics.
+        assert "pressure" in backend.client.experiment.metrics
+        # ...and the OutcomeConstraint references the constraint metric.
+        opt_cfg = backend.client.experiment.optimization_config
+        constraint_names = [oc.metric.name for oc in opt_cfg.outcome_constraints]
+        assert constraint_names == ["pressure"]
+        assert opt_cfg.outcome_constraints[0].relative is False
+
+    def test_constraint_emits_outcome_constraint_in_optimization_config(self, make_dim):
+        backend = AxBackend()
+        backend.set_search_space([make_dim()])
+        backend.set_objectives(
+            [Objective(name="score", minimize=True, objective_function=lambda c: 1.0)]
+        )
+        backend.set_constraints(
+            [
+                Constraint(
+                    name="pressure",
+                    objective_function=lambda c: 50.0,
+                    gte=45.0,
+                    lte=100.0,
+                )
+            ]
+        )
+        backend.initialize()
+
+        opt_cfg = backend.client.experiment.optimization_config
+        bounds_by_op = {
+            (oc.op.name, oc.bound): oc for oc in opt_cfg.outcome_constraints
+        }
+        assert ("GEQ", 45.0) in bounds_by_op
+        assert ("LEQ", 100.0) in bounds_by_op
+        assert all(oc.relative is False for oc in opt_cfg.outcome_constraints)
+        assert all(oc.metric.name == "pressure" for oc in opt_cfg.outcome_constraints)
+
+    def test_bulut_pattern_completes_trial_without_silent_failure(
+        self, tmp_path, caplog, make_suggestion_case
+    ):
+        """Reproducer for issue #24: constraint via set_constraints should
+        cause every trial to complete cleanly, not be silently marked failed."""
+        backend = AxBackend()
+        backend.random_seed = 0
+        backend.initialization_trials = 2
+        backend.set_search_space(
+            [
+                Dimension.range(
+                    name="x",
+                    link=DictionaryLink("constant/setup").entry("x"),
+                    lower=0.0,
+                    upper=1.0,
+                ),
+            ]
+        )
+        objective = Objective(
+            name="totalHeatLoss",
+            minimize=True,
+            objective_function=lambda case: self._read_value(case, "x"),
+        )
+        constraint = Constraint(
+            name="pressure",
+            objective_function=lambda case: 50.0,  # constant, satisfies gte=45
+            gte=45.0,
+        )
+        backend.set_objectives([objective])
+        backend.set_constraints([constraint])
+        backend.initialize()
+
+        # Drive a few trials end-to-end.
+        cases = []
+        with caplog.at_level(logging.WARNING):
+            for cycle in range(3):
+                params = backend.ask(max_cases=1)[0]
+                p = {dim.name: value for dim, value in params.items()}
+                case = make_suggestion_case(
+                    tmp_path, f"trial-{cycle:02d}", {"x": p["x"]}
+                )
+                cases.append(case)
+                objective.batch_evaluate(cases)
+                constraint.batch_evaluate(cases)
+                backend.tell(cases)
+
+        # The smoking-gun warning Ax emits when a metric in raw_data is missing.
+        assert not any(
+            "Marking the trial as failed" in record.message for record in caplog.records
+        ), (
+            "Trials should not be silently marked failed; constraint values are in raw_data"
+        )
+
+        # All trials completed.
+        for case in cases:
+            trial = backend.client.experiment.trials[
+                backend._trial_index_case_mapping[case]
+            ]
+            assert trial.status.is_completed
+
+    def test_no_constraints_means_no_optimization_config_override(self, make_dim):
+        """Sanity: if no constraints and no scalarized objective, Ax's default
+        config is left in place — no unnecessary overrides."""
+        backend = AxBackend()
+        backend.set_search_space([make_dim()])
+        backend.set_objectives(
+            [Objective(name="score", minimize=True, objective_function=lambda c: 1.0)]
+        )
+        backend.initialize()
+
+        opt_cfg = backend.client.experiment.optimization_config
+        assert opt_cfg.outcome_constraints == []
+
+    def test_metric_name_clash_between_objective_and_constraint_rejected(
+        self, make_dim
+    ):
+        backend = AxBackend()
+        backend.set_search_space([make_dim()])
+        backend.set_objectives(
+            [Objective(name="dup", minimize=True, objective_function=lambda c: 1.0)]
+        )
+        backend.set_constraints(
+            [Constraint(name="dup", objective_function=lambda c: 1.0, gte=0.0)]
+        )
+        with pytest.raises(ValueError, match="unique"):
+            backend._verify_configuration()
+
+
+class TestSetConstraintsTypeCheck:
+    """Guards the `set_constraints` arg so misuse fails loudly at registration
+    time instead of crashing later with an AttributeError inside evaluate().
+    """
+
+    def test_rejects_objective_in_list(self):
+        backend = AxBackend()
+        obj = Objective(name="o", minimize=True, objective_function=lambda c: 1.0)
+        with pytest.raises(TypeError, match="must be a Constraint"):
+            backend.set_constraints([obj])  # type: ignore[list-item]
+
+    def test_rejects_string_in_list(self):
+        backend = AxBackend()
+        with pytest.raises(TypeError, match="must be a Constraint"):
+            backend.set_constraints(["not a constraint"])  # type: ignore[list-item]
+
+    def test_rejects_non_iterable_non_constraint(self):
+        backend = AxBackend()
+        with pytest.raises(TypeError, match="expects a Constraint or an iterable"):
+            backend.set_constraints(42)  # type: ignore[arg-type]
+
+    def test_accepts_single_constraint_instance(self):
+        backend = AxBackend()
+        c = Constraint(name="c", objective_function=lambda c: 1.0, gte=0.0)
+        backend.set_constraints(c)  # type: ignore[arg-type]
+        assert backend.constraints == [c]
+
+    def test_accepts_tuple_of_constraints(self):
+        backend = AxBackend()
+        c1 = Constraint(name="c1", objective_function=lambda c: 1.0, gte=0.0)
+        c2 = Constraint(name="c2", objective_function=lambda c: 2.0, lte=5.0)
+        backend.set_constraints((c1, c2))  # type: ignore[arg-type]
+        assert backend.constraints == [c1, c2]
+
+
+@pytest.mark.slow
+class TestMOOWithConstraint:
+    """End-to-end: Ax MOO (two Objectives, no ScalarizedObjective) with a
+    tracking Constraint. Exercises the qEHVI + OutcomeConstraint path that
+    none of the single-objective canaries hit. This is the exact pattern from
+    issue #24 (two heat objectives + a pressure constraint).
+
+    Setup: two paraboloids with minima at (0, 0) and (3, 0), both minimized.
+    The feasibility constraint y >= 1.0 pushes the Pareto front onto the
+    y=1 line, so the reachable corners are (0, 1) (f1=1, f2=10) and (3, 1)
+    (f1=10, f2=1). If the constraint is being respected, BO explores both
+    corners. If it's being ignored (OutcomeConstraint not installed or not
+    honored by qEHVI), BO drifts toward (0, 0) and (3, 0) — infeasible — and
+    the feasible trials are limited to whatever Sobol init happened to sample.
+    """
+
+    N_INIT = 5
+    N_BO = 40
+    PARETO_CORNER_TOLERANCE = 3.0  # near-corner threshold for f1/f2
+
+    def test_bo_explores_constrained_pareto_front(self, tmp_path, make_suggestion_case):
+        backend = AxBackend()
+        backend.random_seed = 0
+        backend.initialization_trials = self.N_INIT
+
+        def _read(case, key):
+            return float(case.read_metadata()["optimizer-suggestion"][key]["value"])
+
+        # Thresholds bound qEHVI's reference point so hypervolume is
+        # well-defined across the search space.
+        f1 = Objective(
+            name="f1",
+            minimize=True,
+            objective_function=lambda case: (
+                _read(case, "x") ** 2 + _read(case, "y") ** 2
+            ),
+            threshold=15.0,
+        )
+        f2 = Objective(
+            name="f2",
+            minimize=True,
+            objective_function=lambda case: (
+                (_read(case, "x") - 3.0) ** 2 + _read(case, "y") ** 2
+            ),
+            threshold=15.0,
+        )
+        y_bound = Constraint(
+            name="y_bound",
+            objective_function=lambda case: _read(case, "y"),
+            gte=1.0,
+        )
+
+        backend.set_search_space(
+            [
+                Dimension.range(
+                    name="x",
+                    link=DictionaryLink("constant/setup").entry("x"),
+                    lower=-2.0,
+                    upper=5.0,
+                ),
+                Dimension.range(
+                    name="y",
+                    link=DictionaryLink("constant/setup").entry("y"),
+                    lower=-2.0,
+                    upper=3.0,
+                ),
+            ]
+        )
+        backend.set_objectives([f1, f2])
+        backend.set_constraints([y_bound])
+        backend.initialize()
+
+        cases: list[Case] = []
+        feasible_f1_values: list[float] = []
+        feasible_f2_values: list[float] = []
+
+        for cycle in range(self.N_INIT + self.N_BO):
+            suggestion = backend.ask(max_cases=1)[0]
+            params = {dim.name: value for dim, value in suggestion.items()}
+            case = make_suggestion_case(tmp_path, f"trial-{cycle:02d}", params)
+            cases.append(case)
+            f1.batch_evaluate(cases)
+            f2.batch_evaluate(cases)
+            y_bound.batch_evaluate(cases)
+            backend.tell(cases)
+
+            y_val = y_bound.data_for_case(case)
+            if y_val is not None and y_val >= 1.0:
+                feasible_f1_values.append(f1.data_for_case(case))
+                feasible_f2_values.append(f2.data_for_case(case))
+
+        assert feasible_f1_values, (
+            f"BO produced no feasible trials across {self.N_INIT + self.N_BO} "
+            f"cycles. Constraint values likely aren't reaching Ax, or qEHVI "
+            f"isn't using the OutcomeConstraint at all."
+        )
+
+        min_f1 = min(feasible_f1_values)
+        min_f2 = min(feasible_f2_values)
+
+        assert min_f1 < self.PARETO_CORNER_TOLERANCE, (
+            f"BO didn't find a feasible trial near the (0, 1) Pareto corner. "
+            f"Best feasible f1={min_f1:.3f} (target < {self.PARETO_CORNER_TOLERANCE}). "
+            f"qEHVI is probably not exploring that end of the feasible front."
+        )
+        assert min_f2 < self.PARETO_CORNER_TOLERANCE, (
+            f"BO didn't find a feasible trial near the (3, 1) Pareto corner. "
+            f"Best feasible f2={min_f2:.3f} (target < {self.PARETO_CORNER_TOLERANCE}). "
+            f"qEHVI is probably not exploring that end of the feasible front."
+        )
+
+
+class TestMOOWithObjectiveBounds:
+    """Top-level MOO with Objective(..., gte/lte) takes a separate Ax path from
+    single-objective bounds: the config must stay MultiObjectiveOptimizationConfig
+    while adding OutcomeConstraints on the derived bound tracking metric.
+    """
+
+    def test_bounded_objective_preserves_moo_config_and_completes_trial(
+        self, tmp_path, make_suggestion_case
+    ):
+        from ax.core.optimization_config import MultiObjectiveOptimizationConfig
+
+        backend = AxBackend()
+        backend.random_seed = 0
+        backend.initialization_trials = 1
+
+        def _read(case, key):
+            return float(case.read_metadata()["optimizer-suggestion"][key]["value"])
+
+        drag = Objective(
+            name="drag",
+            minimize=True,
+            objective_function=lambda case: _read(case, "x") ** 2,
+            lte=0.5,
+            threshold=2.0,
+        )
+        lift = Objective(
+            name="lift",
+            minimize=False,
+            objective_function=lambda case: 1.0 + _read(case, "x"),
+            gte=1.25,
+            threshold=0.0,
+        )
+
+        backend.set_search_space(
+            [
+                Dimension.range(
+                    name="x",
+                    link=DictionaryLink("constant/setup").entry("x"),
+                    lower=0.0,
+                    upper=1.0,
+                ),
+            ]
+        )
+        backend.set_objectives([drag, lift])
+        backend.initialize()
+
+        opt_cfg = backend.client.experiment.optimization_config
+        assert isinstance(opt_cfg, MultiObjectiveOptimizationConfig)
+        assert {
+            (oc.metric.name, oc.op.name, oc.bound, oc.relative)
+            for oc in opt_cfg.outcome_constraints
+        } == {
+            ("drag__bound", "LEQ", 0.5, False),
+            ("lift__bound", "GEQ", 1.25, False),
+        }
+
+        case = make_suggestion_case(tmp_path, "finished", {"x": 0.5})
+        drag.batch_evaluate([case])
+        lift.batch_evaluate([case])
+        backend.tell([case])
+
+        trial = backend.client.get_trial(backend._trial_index_case_mapping[case])
+        assert trial.status.is_completed
+        metric_names = set(backend.client.experiment.fetch_data().df["metric_name"])
+        assert {"drag", "drag__bound", "lift", "lift__bound"} <= metric_names
+
+
+@pytest.mark.slow
+class TestConstraintConvergenceCanary:
+    """BO on an unconstrained quadratic whose minimum lies outside a feasible
+    region defined by a Constraint. If Ax's OutcomeConstraint integration
+    regresses (bound not applied, or the tracking metric isn't registered),
+    BO drifts toward the unconstrained optimum and never finds a feasible
+    low-objective point; the assertion on best-feasible objective value
+    catches that.
+    """
+
+    N_INIT = 5
+    N_BO = 20
+    CONSTRAINED_OPT = 4.0  # f = x1**2 + x2**2 at (x1=2, x2=0), subject to x1 >= 2
+    TOLERANCE = 2.0  # ~50% slack; broken path typically lands at 8-15
+
+    def test_bo_concentrates_in_feasible_region(self, tmp_path, make_suggestion_case):
+        backend = AxBackend()
+        backend.random_seed = 0
+        backend.initialization_trials = self.N_INIT
+
+        def _read(case, key):
+            return float(case.read_metadata()["optimizer-suggestion"][key]["value"])
+
+        objective = Objective(
+            name="f",
+            minimize=True,
+            objective_function=lambda case: (
+                _read(case, "x1") ** 2 + _read(case, "x2") ** 2
+            ),
+        )
+        constraint = Constraint(
+            name="x1_bound",
+            objective_function=lambda case: _read(case, "x1"),
+            gte=2.0,
+        )
+
+        backend.set_search_space(
+            [
+                Dimension.range(
+                    name="x1",
+                    link=DictionaryLink("constant/setup").entry("x1"),
+                    lower=-5.0,
+                    upper=5.0,
+                ),
+                Dimension.range(
+                    name="x2",
+                    link=DictionaryLink("constant/setup").entry("x2"),
+                    lower=-5.0,
+                    upper=5.0,
+                ),
+            ]
+        )
+        backend.set_objectives([objective])
+        backend.set_constraints([constraint])
+        backend.initialize()
+
+        cases = []
+        best_feasible = float("inf")
+
+        for cycle in range(self.N_INIT + self.N_BO):
+            suggestion = backend.ask(max_cases=1)[0]
+            params = {dim.name: value for dim, value in suggestion.items()}
+            case = make_suggestion_case(tmp_path, f"trial-{cycle:02d}", params)
+            cases.append(case)
+            objective.batch_evaluate(cases)
+            constraint.batch_evaluate(cases)
+            backend.tell(cases)
+
+            f_val = objective.data_for_case(case)
+            c_val = constraint.data_for_case(case)
+            assert f_val is not None and c_val is not None
+            if c_val >= 2.0:
+                best_feasible = min(best_feasible, f_val)
+
+        assert best_feasible - self.CONSTRAINED_OPT < self.TOLERANCE, (
+            f"BO failed to find a near-optimal feasible point. Best feasible "
+            f"f: {best_feasible:.4f} (target: {self.CONSTRAINED_OPT:.4f} "
+            f"± {self.TOLERANCE}). Likely that Ax's OutcomeConstraint is no "
+            f"longer being installed or respected at acquisition time."
+        )
+
+
+class TestBatchProcessWithConstraints:
+    def test_batch_process_persists_constraint_outputs(self, tmp_path, make_dim):
+        """`batch_process` must evaluate constraints alongside objectives and
+        write their values to `metadata["constraint-outputs"]` with gte/lte
+        annotations."""
+        backend = AxBackend()
+        backend.set_search_space([make_dim()])
+        backend.set_objectives(
+            [Objective(name="score", minimize=True, objective_function=lambda c: 1.0)]
+        )
+        backend.set_constraints(
+            [
+                Constraint(
+                    name="pressure",
+                    objective_function=lambda c: 50.0,
+                    gte=45.0,
+                    lte=100.0,
+                )
+            ]
+        )
+
+        case_dir = tmp_path / "case"
+        case_dir.mkdir()
+        case = Case(case_dir)
+
+        backend.batch_process([case])
+
+        metadata = case.read_metadata()
+        assert metadata is not None
+        assert metadata["objective-outputs"]["score"]["value"] == 1.0
+        assert metadata["constraint-outputs"]["pressure"]["value"] == 50.0
+        assert metadata["constraint-outputs"]["pressure"]["gte"] == 45.0
+        assert metadata["constraint-outputs"]["pressure"]["lte"] == 100.0
+
+    def test_batch_process_without_constraints_omits_section(self, tmp_path, make_dim):
+        """Don't write an empty constraint-outputs section when there are no
+        constraints — keeps metadata.toml uncluttered for the common case."""
+        backend = AxBackend()
+        backend.set_search_space([make_dim()])
+        backend.set_objectives(
+            [Objective(name="score", minimize=True, objective_function=lambda c: 1.0)]
+        )
+
+        case_dir = tmp_path / "case"
+        case_dir.mkdir()
+        case = Case(case_dir)
+
+        backend.batch_process([case])
+
+        metadata = case.read_metadata()
+        assert metadata is not None
+        assert "constraint-outputs" not in metadata
+
+
+class TestOffloadedAcquisitionWithConstraints:
+    """Coverage for the acquisition-offload round-trip when constraints are
+    registered. The snapshot already includes the constraint metric values
+    via `objective_function_outputs`; the receiving side must feed them into
+    `raw_data` so the reconstructed experiment doesn't hit the silent-failure
+    mode that motivated this PR."""
+
+    def test_data_snapshot_includes_constraint_values(
+        self, tmp_path, make_dim, make_suggestion_case
+    ):
+        backend = AxBackend()
+        backend.offload_acquisition = True
+        backend.set_search_space([make_dim(name="x")])
+        objective = Objective(
+            name="score", minimize=True, objective_function=lambda c: 1.0
+        )
+        constraint = Constraint(
+            name="pressure", objective_function=lambda c: 55.0, gte=45.0
+        )
+        backend.set_objectives([objective])
+        backend.set_constraints([constraint])
+        backend.initialize()
+
+        case = make_suggestion_case(tmp_path, "finished", {"x": 0.5})
+        objective.batch_evaluate([case])
+        constraint.batch_evaluate([case])
+
+        _, data_snapshot = backend.prepare_for_acquisition_offload([case], [], tmp_path)
+        snapshot = json.loads(data_snapshot.read_text())
+        objectives_dict = snapshot["finished_cases"][case.name]["objectives"]
+        # Both objective and constraint metric values are in the snapshot.
+        assert objectives_dict == {"score": 1.0, "pressure": 55.0}
+
+    def test_offloaded_round_trip_with_constraint(
+        self, tmp_path, make_dim, make_suggestion_case
+    ):
+        backend = AxBackend()
+        backend.offload_acquisition = True
+        backend.random_seed = 0
+        backend.initialization_trials = 1
+        backend.set_search_space([make_dim(name="x")])
+        objective = Objective(
+            name="score", minimize=True, objective_function=lambda c: 1.0
+        )
+        constraint = Constraint(
+            name="pressure", objective_function=lambda c: 55.0, gte=45.0
+        )
+        backend.set_objectives([objective])
+        backend.set_constraints([constraint])
+        backend.initialize()
+
+        case = make_suggestion_case(tmp_path, "finished", {"x": 0.5})
+        objective.batch_evaluate([case])
+        constraint.batch_evaluate([case])
+
+        model_snapshot, data_snapshot = backend.prepare_for_acquisition_offload(
+            [case], [], tmp_path
+        )
+        output_path = tmp_path / "acquisition_result.json"
+
+        AxBackend.offloaded_acquisition(
+            model_snapshot=model_snapshot,
+            data_snapshot=data_snapshot,
+            num_trials=1,
+            output_path=output_path,
+        )
+
+        result = json.loads(output_path.read_text())
+        assert result["optimizer"] == "AxBackend"
+        assert len(result["parametrizations"]) == 1
+
+
+class TestOffloadedAcquisitionWithObjectiveBounds:
+    """Acquisition offload must serialize and replay the derived bound alias for
+    bounded Objectives, not only explicit Constraint metrics.
+    """
+
+    def test_offloaded_round_trip_with_bounded_objective(
+        self, tmp_path, make_dim, make_suggestion_case
+    ):
+        backend = AxBackend()
+        backend.offload_acquisition = True
+        backend.random_seed = 0
+        backend.initialization_trials = 1
+        backend.set_search_space([make_dim(name="x")])
+        objective = Objective(
+            name="score",
+            minimize=True,
+            objective_function=lambda c: 0.4,
+            lte=0.5,
+        )
+        backend.set_objectives([objective])
+        backend.initialize()
+
+        case = make_suggestion_case(tmp_path, "finished", {"x": 0.5})
+        objective.batch_evaluate([case])
+
+        model_snapshot, data_snapshot = backend.prepare_for_acquisition_offload(
+            [case], [], tmp_path
+        )
+        snapshot = json.loads(data_snapshot.read_text())
+        assert snapshot["finished_cases"][case.name]["objectives"] == {
+            "score": 0.4,
+            "score__bound": 0.4,
+        }
+
+        output_path = tmp_path / "acquisition_result.json"
+        AxBackend.offloaded_acquisition(
+            model_snapshot=model_snapshot,
+            data_snapshot=data_snapshot,
+            num_trials=1,
+            output_path=output_path,
+        )
+
+        result = json.loads(output_path.read_text())
+        assert result["optimizer"] == "AxBackend"
+        assert len(result["parametrizations"]) == 1
+
+
+@pytest.mark.slow
+class TestSessionLoopWithConstraint:
+    """End-to-end: drive Session.local_optimization with a real AxBackend
+    configured with a Constraint. The manager/job cycle is replaced by
+    directly staging 'completed' cases in the archival dir between iterations.
+
+    Catches orchestration bugs where constraint values might be dropped in
+    the finished-case → batch_process → tell handoff, or where the next ask()
+    ignores constraint values that did reach the backend. The single-object
+    canary above drives ask/tell directly; this one drives the Session layer.
+    """
+
+    N_INIT = 5
+    N_CYCLES = 15
+    FEASIBLE_OPT_F = 1.0  # x=1, f=x**2
+    TOLERANCE = 3.0  # slack for surrogate noise + Sobol warm-up
+
+    def _make_foam_dir(self, path):
+        path.mkdir(parents=True, exist_ok=True)
+        (path / "constant").mkdir(exist_ok=True)
+        (path / "system").mkdir(exist_ok=True)
+        return path
+
+    def _stage_finished_case(self, session, case_idx, x_val):
+        """Put a 'completed' case in the archival dir with suggestion metadata
+        set — simulates a job that ran and finished outside this test."""
+        name = f"job_{case_idx:05d}_{case_idx:08x}"
+        case_dir = self._make_foam_dir(session.archival_dir / name)
+        case = Case(case_dir)
+        case.update_metadata(
+            {"x": {"value": float(x_val)}},
+            entry_header="optimizer-suggestion",
+        )
+        case.success = True
+        case.persist_to_file()
+        return case
+
+    def test_session_loop_drives_ax_with_constraint(self, tmp_path):
+        import random
+
+        from flowboost.session.session import Session
+
+        session = Session(name="t", data_dir=tmp_path / "session")
+
+        # Reconfigure the backend Session created by default.
+        backend = AxBackend()
+        backend.random_seed = 0
+        backend.initialization_trials = self.N_INIT
+        backend.set_search_space(
+            [
+                Dimension.range(
+                    name="x",
+                    link=DictionaryLink("constant/setup").entry("x"),
+                    lower=-5.0,
+                    upper=5.0,
+                ),
+            ]
+        )
+
+        def _read(case, key):
+            return float(case.read_metadata()["optimizer-suggestion"][key]["value"])
+
+        # Unconstrained optimum at x=0 (f=0); constraint x >= 1 shifts
+        # constrained optimum to x=1 (f=1). If constraint values are dropped
+        # anywhere in the Session → Backend handoff, BO drifts toward x=0.
+        objective = Objective(
+            name="f",
+            minimize=True,
+            objective_function=lambda c: _read(c, "x") ** 2,
+        )
+        constraint = Constraint(
+            name="x_bound",
+            objective_function=lambda c: _read(c, "x"),
+            gte=1.0,
+        )
+        backend.set_objectives([objective])
+        backend.set_constraints([constraint])
+        session.backend = backend
+        backend.initialize()
+
+        # Seed the archival dir with Sobol-like starting data. Without this,
+        # the first local_optimization call has nothing to tell() the backend
+        # with and Ax just generates more Sobol points instead of exercising
+        # the BO + constraint path we care about.
+        rng = random.Random(42)
+        for i in range(self.N_INIT):
+            self._stage_finished_case(session, i, rng.uniform(-5.0, 5.0))
+
+        # Drive the session loop: each cycle produces a suggestion, which we
+        # stage as finished for the next iteration. Exercises the full
+        # batch_process → tell → ask pipeline.
+        x_trajectory: list[float] = []
+        best_feasible = float("inf")
+
+        for cycle in range(self.N_CYCLES):
+            suggestions = session.local_optimization(num_new_cases=1)
+            assert len(suggestions) == 1, (
+                f"cycle {cycle}: expected 1 suggestion, got {len(suggestions)}"
+            )
+
+            dim_to_value = suggestions[0]
+            x_val = float(next(iter(dim_to_value.values())))
+            x_trajectory.append(x_val)
+
+            # Stage this suggestion as a finished case for the next cycle.
+            self._stage_finished_case(session, 1000 + cycle, x_val)
+
+            f_val = x_val**2
+            if x_val >= 1.0:
+                best_feasible = min(best_feasible, f_val)
+
+        # Loop completed without raising — orchestration handshake is intact.
+        # Best feasible f close to the constrained optimum — constraint
+        # information actually influenced acquisition across the Session.
+        assert best_feasible - self.FEASIBLE_OPT_F < self.TOLERANCE, (
+            f"Session-driven BO didn't find a near-optimal feasible point. "
+            f"Best feasible f={best_feasible:.4f} "
+            f"(target: {self.FEASIBLE_OPT_F} ± {self.TOLERANCE}). "
+            f"Trajectory: {['%.3f' % x for x in x_trajectory]}. "
+            f"If constraint values were lost between Case metadata and "
+            f"backend.tell(), BO would drift toward x=0 and this would fail."
+        )
+
+        # Sanity: late-cycle trials should cluster near the feasible region.
+        # Soft OutcomeConstraints don't enforce strict feasibility — Ax's
+        # acquisition lands arbitrarily close to the bound (e.g. x=0.999 with
+        # gte=1.0), so a 10% tolerance accommodates that while still catching
+        # "BO ignores the constraint and drifts toward the unconstrained
+        # optimum at x=0".
+        late_near_feasible = sum(1 for x in x_trajectory[-5:] if x >= 0.9)
+        assert late_near_feasible >= 2, (
+            f"Only {late_near_feasible}/5 of the last cycles landed at or "
+            f"above the constraint boundary. Late trajectory: "
+            f"{['%.3f' % x for x in x_trajectory[-5:]]}. BO doesn't appear "
+            f"to be steering toward the feasible region."
+        )
+
+
+@pytest.mark.slow
+class TestSessionLoopWithObjectiveBounds:
+    """End-to-end Session loop for Objective(..., gte/lte) sugar.
+
+    This catches regressions where the derived `{objective}__bound` metric is
+    registered at Ax setup time but lost in the Session → batch_process → tell
+    handoff during repeated stateless replay.
+    """
+
+    N_INIT = 5
+    N_CYCLES = 15
+    CONSTRAINED_OPT = 1.0  # f=x**2 with f >= 1.0; optimum lies at x=±1.
+    TOLERANCE = 0.5
+    NEAR_BOUNDARY_VALUE = 0.9
+
+    def _make_foam_dir(self, path):
+        path.mkdir(parents=True, exist_ok=True)
+        (path / "constant").mkdir(exist_ok=True)
+        (path / "system").mkdir(exist_ok=True)
+        return path
+
+    def _stage_finished_case(self, session, case_idx, x_val):
+        name = f"job_{case_idx:05d}_{case_idx:08x}"
+        case_dir = self._make_foam_dir(session.archival_dir / name)
+        case = Case(case_dir)
+        case.update_metadata(
+            {"x": {"value": float(x_val)}},
+            entry_header="optimizer-suggestion",
+        )
+        case.success = True
+        case.persist_to_file()
+        return case
+
+    def test_session_loop_drives_ax_with_bounded_objective(self, tmp_path):
+        import random
+
+        from flowboost.session.session import Session
+
+        session = Session(name="t", data_dir=tmp_path / "session")
+        backend = AxBackend()
+        backend.random_seed = 0
+        backend.initialization_trials = self.N_INIT
+        backend.set_search_space(
+            [
+                Dimension.range(
+                    name="x",
+                    link=DictionaryLink("constant/setup").entry("x"),
+                    lower=-5.0,
+                    upper=5.0,
+                ),
+            ]
+        )
+
+        def _read(case, key):
+            return float(case.read_metadata()["optimizer-suggestion"][key]["value"])
+
+        objective = Objective(
+            name="f",
+            minimize=True,
+            objective_function=lambda c: _read(c, "x") ** 2,
+            gte=1.0,
+        )
+        backend.set_objectives([objective])
+        session.backend = backend
+        backend.initialize()
+
+        rng = random.Random(42)
+        for i in range(self.N_INIT):
+            self._stage_finished_case(session, i, rng.uniform(-5.0, 5.0))
+
+        x_trajectory: list[float] = []
+        best_near_boundary = float("inf")
+        for cycle in range(self.N_CYCLES):
+            suggestions = session.local_optimization(num_new_cases=1)
+            assert len(suggestions) == 1, (
+                f"cycle {cycle}: expected 1 suggestion, got {len(suggestions)}"
+            )
+            x_val = float(next(iter(suggestions[0].values())))
+            x_trajectory.append(x_val)
+            self._stage_finished_case(session, 1000 + cycle, x_val)
+
+            f_val = x_val**2
+            if f_val >= self.NEAR_BOUNDARY_VALUE:
+                best_near_boundary = min(best_near_boundary, f_val)
+
+        failed_trials = [
+            trial
+            for trial in backend.client.experiment.trials.values()
+            if trial.status.is_failed
+        ]
+        assert failed_trials == []
+
+        metric_names = set(backend.client.experiment.fetch_data().df["metric_name"])
+        assert {"f", "f__bound"} <= metric_names
+
+        assert best_near_boundary - self.CONSTRAINED_OPT < self.TOLERANCE, (
+            f"Session-driven bounded Objective BO didn't find a near-boundary "
+            f"point. Best near-boundary f={best_near_boundary:.4f} "
+            f"(target: {self.CONSTRAINED_OPT} ± {self.TOLERANCE}). "
+            f"Trajectory: {['%.3f' % x for x in x_trajectory]}."
+        )
+
+        late_near_feasible = sum(
+            1 for x in x_trajectory[-5:] if x**2 >= self.NEAR_BOUNDARY_VALUE
+        )
+        assert late_near_feasible >= 3, (
+            f"Only {late_near_feasible}/5 late cycles landed near the bounded "
+            f"objective's feasible boundary. Late trajectory: "
+            f"{['%.3f' % x for x in x_trajectory[-5:]]}."
+        )
+
+
+class TestObjectiveBoundsIntegration:
+    """`Objective(..., gte=/lte=)` sugar: bound is attached to a derived
+    tracking metric at Ax setup time so that Ax never sees a constraint on
+    an objective metric directly. These tests pin that wiring and assert the
+    sugar behaves identically to the explicit `Objective + Constraint` dual
+    registration under a fixed random seed.
+    """
+
+    def test_derived_tracking_metric_registered_on_experiment(self, make_dim):
+        backend = AxBackend()
+        backend.set_search_space([make_dim()])
+        backend.set_objectives(
+            [
+                Objective(
+                    name="drag",
+                    minimize=True,
+                    objective_function=lambda c: 0.04,
+                    lte=0.05,
+                )
+            ]
+        )
+        backend.initialize()
+
+        assert "drag" in backend.client.experiment.metrics
+        assert "drag__bound" in backend.client.experiment.metrics
+
+    def test_outcome_constraint_wired_to_derived_metric(self, make_dim):
+        backend = AxBackend()
+        backend.set_search_space([make_dim()])
+        backend.set_objectives(
+            [
+                Objective(
+                    name="drag",
+                    minimize=True,
+                    objective_function=lambda c: 0.04,
+                    gte=0.01,
+                    lte=0.05,
+                )
+            ]
+        )
+        backend.initialize()
+
+        opt_cfg = backend.client.experiment.optimization_config
+        wired = {
+            (oc.metric.name, oc.op.name, oc.bound) for oc in opt_cfg.outcome_constraints
+        }
+        assert wired == {("drag__bound", "GEQ", 0.01), ("drag__bound", "LEQ", 0.05)}
+        assert all(oc.relative is False for oc in opt_cfg.outcome_constraints)
+
+    def test_derived_name_collision_rejected(self, make_dim):
+        """If the user registers a Constraint with the same name as an
+        Objective's derived bound metric, `_verify_configuration` must catch
+        the clash before Ax sees a duplicate metric."""
+        backend = AxBackend()
+        backend.set_search_space([make_dim()])
+        backend.set_objectives(
+            [
+                Objective(
+                    name="drag",
+                    minimize=True,
+                    objective_function=lambda c: 0.04,
+                    lte=0.05,
+                )
+            ]
+        )
+        backend.set_constraints(
+            [
+                Constraint(
+                    name="drag__bound",
+                    objective_function=lambda c: 0.04,
+                    lte=0.05,
+                )
+            ]
+        )
+        with pytest.raises(ValueError, match="unique"):
+            backend._verify_configuration()
+
+    def test_batch_process_persists_objective_bounds_in_metadata(
+        self, tmp_path, make_dim
+    ):
+        """The metadata-facing view of a bounded Objective is a single
+        objective-outputs entry carrying `gte`/`lte` alongside `value`, not
+        a separate constraint-outputs entry for the derived name."""
+        backend = AxBackend()
+        backend.set_search_space([make_dim()])
+        backend.set_objectives(
+            [
+                Objective(
+                    name="drag",
+                    minimize=True,
+                    objective_function=lambda c: 0.04,
+                    lte=0.05,
+                )
+            ]
+        )
+
+        case_dir = tmp_path / "case"
+        case_dir.mkdir()
+        case = Case(case_dir)
+        backend.batch_process([case])
+
+        metadata = case.read_metadata()
+        assert metadata is not None
+        assert metadata["objective-outputs"]["drag"]["value"] == 0.04
+        assert metadata["objective-outputs"]["drag"]["lte"] == 0.05
+        assert metadata["objective-outputs"]["drag"]["minimize"] is True
+        # The derived name is an Ax-layer artifact; it should not leak into
+        # the user-facing constraint-outputs section.
+        assert "constraint-outputs" not in metadata
+
+
+@pytest.mark.slow
+class TestObjectiveBoundsEquivalence:
+    """Sugar `Objective(..., gte=X)` must produce the same suggestion
+    trajectory as the explicit `Objective + Constraint("__bound", ...)`
+    pattern under a fixed random seed. Anything else would mean the sugar
+    has a subtly different Ax configuration under the hood.
+    """
+
+    N_INIT = 3
+    N_BO = 10
+
+    def _quad(self, case):
+        return float(case.read_metadata()["optimizer-suggestion"]["x"]["value"]) ** 2
+
+    def _run(self, tmp_path, subdir, setup_fn, make_suggestion_case):
+        case_parent = tmp_path / subdir
+        case_parent.mkdir()
+
+        backend, objective, constraint = setup_fn()
+        backend.random_seed = 0
+        backend.initialization_trials = self.N_INIT
+        backend.set_search_space(
+            [
+                Dimension.range(
+                    name="x",
+                    link=DictionaryLink("constant/setup").entry("x"),
+                    lower=-5.0,
+                    upper=5.0,
+                ),
+            ]
+        )
+        backend.initialize()
+
+        trajectory = []
+        cases = []
+        for cycle in range(self.N_INIT + self.N_BO):
+            suggestion = backend.ask(max_cases=1)[0]
+            params = {d.name: v for d, v in suggestion.items()}
+            case = make_suggestion_case(case_parent, f"trial-{cycle:02d}", params)
+            cases.append(case)
+            objective.batch_evaluate(cases)
+            if constraint is not None:
+                constraint.batch_evaluate(cases)
+            backend.tell(cases)
+            trajectory.append(float(params["x"]))
+        return trajectory
+
+    def test_sugar_matches_explicit_dual_registration(
+        self, tmp_path, make_suggestion_case
+    ):
+        def sugar():
+            backend = AxBackend()
+            obj = Objective(
+                name="f",
+                minimize=True,
+                objective_function=self._quad,
+                gte=2.0,
+            )
+            backend.set_objectives([obj])
+            return backend, obj, None
+
+        def explicit():
+            backend = AxBackend()
+            obj = Objective(name="f", minimize=True, objective_function=self._quad)
+            con = Constraint(
+                name="f__bound",
+                objective_function=self._quad,
+                gte=2.0,
+            )
+            backend.set_objectives([obj])
+            backend.set_constraints([con])
+            return backend, obj, con
+
+        sugar_traj = self._run(tmp_path, "sugar", sugar, make_suggestion_case)
+        explicit_traj = self._run(tmp_path, "explicit", explicit, make_suggestion_case)
+
+        assert sugar_traj == pytest.approx(explicit_traj, abs=1e-9), (
+            f"Sugar and explicit-dual trajectories diverge. "
+            f"Sugar: {[f'{x:.4f}' for x in sugar_traj]} "
+            f"Explicit: {[f'{x:.4f}' for x in explicit_traj]}. "
+            f"The sugar must produce an identical Ax configuration."
+        )
+
+
+class TestScalarizedInnerBoundsIntegration:
+    """Inner Objectives inside a ScalarizedObjective may carry bounds. Each
+    bounded inner produces a derived tracking metric at the Ax layer, with
+    OutcomeConstraints on it. The scalarized sum remains the optimization
+    target; the bound steers acquisition away from violating the inner term.
+    """
+
+    def test_derived_tracking_metric_registered_for_inner(self, make_dim):
+        backend = AxBackend()
+        backend.set_search_space([make_dim()])
+        inner_bounded = Objective(
+            name="drag",
+            minimize=True,
+            objective_function=lambda c: 0.04,
+            lte=0.05,
+        )
+        inner_plain = Objective(
+            name="lift",
+            minimize=False,
+            objective_function=lambda c: 1.0,
+        )
+        backend.set_objectives(
+            ScalarizedObjective(
+                "ratio",
+                minimize=False,
+                objectives=[inner_plain, inner_bounded],
+                weights=[0.7, -0.3],
+            )
+        )
+        backend.initialize()
+
+        metrics = backend.client.experiment.metrics
+        assert "lift" in metrics
+        assert "drag" in metrics
+        assert "drag__bound" in metrics
+        assert "lift__bound" not in metrics
+
+    def test_outcome_constraint_wired_to_inner_derived_metric(self, make_dim):
+        backend = AxBackend()
+        backend.set_search_space([make_dim()])
+        backend.set_objectives(
+            ScalarizedObjective(
+                "ratio",
+                minimize=False,
+                objectives=[
+                    Objective(
+                        name="lift",
+                        minimize=False,
+                        objective_function=lambda c: 1.0,
+                    ),
+                    Objective(
+                        name="drag",
+                        minimize=True,
+                        objective_function=lambda c: 0.04,
+                        lte=0.05,
+                    ),
+                ],
+                weights=[0.7, -0.3],
+            )
+        )
+        backend.initialize()
+
+        opt_cfg = backend.client.experiment.optimization_config
+        wired = {
+            (oc.metric.name, oc.op.name, oc.bound) for oc in opt_cfg.outcome_constraints
+        }
+        assert wired == {("drag__bound", "LEQ", 0.05)}
+        assert all(oc.relative is False for oc in opt_cfg.outcome_constraints)
+
+    def test_inner_bound_collision_rejected(self, make_dim):
+        """A Constraint named `{inner.name}__bound` collides with the derived
+        tracking metric the inner's bounds would install."""
+        backend = AxBackend()
+        backend.set_search_space([make_dim()])
+        backend.set_objectives(
+            ScalarizedObjective(
+                "ratio",
+                minimize=True,
+                objectives=[
+                    Objective(
+                        name="drag",
+                        minimize=True,
+                        objective_function=lambda c: 0.04,
+                        lte=0.05,
+                    ),
+                    Objective(
+                        name="mass", minimize=True, objective_function=lambda c: 1.0
+                    ),
+                ],
+                weights=[1.0, 1.0],
+            )
+        )
+        backend.set_constraints(
+            [
+                Constraint(
+                    name="drag__bound",
+                    objective_function=lambda c: 0.04,
+                    lte=0.05,
+                )
+            ]
+        )
+        with pytest.raises(ValueError, match="unique"):
+            backend._verify_configuration()
+
+    def test_batch_process_persists_inner_bounds_in_metadata(self, tmp_path, make_dim):
+        """`component_bounds` is an additive sibling of `components`: only
+        present when at least one inner carries bounds, preserving the
+        existing flat `components` shape for the common case."""
+        backend = AxBackend()
+        backend.set_search_space([make_dim()])
+        backend.set_objectives(
+            ScalarizedObjective(
+                "ratio",
+                minimize=True,
+                objectives=[
+                    Objective(
+                        name="drag",
+                        minimize=True,
+                        objective_function=lambda c: 0.04,
+                        lte=0.05,
+                    ),
+                    Objective(
+                        name="mass", minimize=True, objective_function=lambda c: 1.0
+                    ),
+                ],
+                weights=[1.0, 1.0],
+            )
+        )
+
+        case_dir = tmp_path / "case"
+        case_dir.mkdir()
+        case = Case(case_dir)
+        backend.batch_process([case])
+
+        metadata = case.read_metadata()
+        assert metadata is not None
+        entry = metadata["objective-outputs"]["ratio"]
+        assert entry["components"] == {"drag": 0.04, "mass": 1.0}
+        assert entry["component_bounds"] == {"drag": {"lte": 0.05}}
+
+    def test_no_component_bounds_when_no_inner_is_bounded(self, tmp_path, make_dim):
+        backend = AxBackend()
+        backend.set_search_space([make_dim()])
+        backend.set_objectives(
+            ScalarizedObjective(
+                "agg",
+                minimize=True,
+                objectives=[
+                    Objective(
+                        name="a", minimize=True, objective_function=lambda c: 2.0
+                    ),
+                    Objective(
+                        name="b", minimize=True, objective_function=lambda c: 3.0
+                    ),
+                ],
+            )
+        )
+        case_dir = tmp_path / "case"
+        case_dir.mkdir()
+        case = Case(case_dir)
+        backend.batch_process([case])
+
+        metadata = case.read_metadata()
+        assert metadata is not None
+        entry = metadata["objective-outputs"]["agg"]
+        assert entry["components"] == {"a": 2.0, "b": 3.0}
+        assert "component_bounds" not in entry
+
+
+@pytest.mark.slow
+class TestScalarizedInnerBoundsEquivalence:
+    """Inner-bound sugar (`ScalarizedObjective` with a bounded inner Objective)
+    must produce the same BO trajectory under a fixed seed as the explicit
+    pattern: unbounded inner Objectives in the ScalarizedObjective plus an
+    explicit Constraint on the same underlying callable, named after the
+    inner's derived bound metric.
+    """
+
+    N_INIT = 3
+    N_BO = 10
+
+    def _lift(self, case):
+        # Positive, bounded away from zero so maximize is well-behaved.
+        x = float(case.read_metadata()["optimizer-suggestion"]["x"]["value"])
+        return 1.0 + x * 0.1
+
+    def _drag(self, case):
+        # x^2 puts the unconstrained minimum at x=0 (drag=0); the lte=0.5
+        # bound becomes binding once x**2 approaches 0.5 (x~0.7).
+        x = float(case.read_metadata()["optimizer-suggestion"]["x"]["value"])
+        return x**2
+
+    def _run(self, tmp_path, subdir, setup_fn, make_suggestion_case):
+        case_parent = tmp_path / subdir
+        case_parent.mkdir()
+
+        backend, scalarized, constraint = setup_fn()
+        backend.random_seed = 0
+        backend.initialization_trials = self.N_INIT
+        backend.set_search_space(
+            [
+                Dimension.range(
+                    name="x",
+                    link=DictionaryLink("constant/setup").entry("x"),
+                    lower=-3.0,
+                    upper=3.0,
+                ),
+            ]
+        )
+        backend.initialize()
+
+        trajectory = []
+        cases = []
+        for cycle in range(self.N_INIT + self.N_BO):
+            suggestion = backend.ask(max_cases=1)[0]
+            params = {d.name: v for d, v in suggestion.items()}
+            case = make_suggestion_case(case_parent, f"trial-{cycle:02d}", params)
+            cases.append(case)
+            scalarized.batch_evaluate(cases)
+            if constraint is not None:
+                constraint.batch_evaluate(cases)
+            backend.tell(cases)
+            trajectory.append(float(params["x"]))
+        return trajectory
+
+    def test_inner_bound_sugar_matches_explicit_constraint(
+        self, tmp_path, make_suggestion_case
+    ):
+        def sugar():
+            backend = AxBackend()
+            lift = Objective("lift", minimize=False, objective_function=self._lift)
+            drag = Objective(
+                "drag", minimize=True, objective_function=self._drag, lte=0.5
+            )
+            scalarized = ScalarizedObjective(
+                "ratio", minimize=False, objectives=[lift, drag], weights=[0.7, -0.3]
+            )
+            backend.set_objectives(scalarized)
+            return backend, scalarized, None
+
+        def explicit():
+            backend = AxBackend()
+            lift = Objective("lift", minimize=False, objective_function=self._lift)
+            drag = Objective("drag", minimize=True, objective_function=self._drag)
+            scalarized = ScalarizedObjective(
+                "ratio", minimize=False, objectives=[lift, drag], weights=[0.7, -0.3]
+            )
+            con = Constraint(name="drag__bound", objective_function=self._drag, lte=0.5)
+            backend.set_objectives(scalarized)
+            backend.set_constraints([con])
+            return backend, scalarized, con
+
+        sugar_traj = self._run(tmp_path, "sugar", sugar, make_suggestion_case)
+        explicit_traj = self._run(tmp_path, "explicit", explicit, make_suggestion_case)
+
+        assert sugar_traj == pytest.approx(explicit_traj, abs=1e-9), (
+            f"Inner-bound sugar and explicit-Constraint trajectories diverge. "
+            f"Sugar: {[f'{x:.4f}' for x in sugar_traj]} "
+            f"Explicit: {[f'{x:.4f}' for x in explicit_traj]}. The two "
+            f"configurations should produce identical Ax experiments."
+        )

--- a/tests/flowboost/optimizer/test_determinism.py
+++ b/tests/flowboost/optimizer/test_determinism.py
@@ -19,11 +19,12 @@ import pytest
 from flowboost.openfoam.case import Case
 from flowboost.openfoam.dictionary import DictionaryLink
 from flowboost.optimizer.interfaces.Ax import AxBackend
-from flowboost.optimizer.objectives import Objective
+from flowboost.optimizer.objectives import Constraint, Objective, ScalarizedObjective
 from flowboost.optimizer.search_space import Dimension
 
 SEED = 42
 N_CYCLES = 6
+SCALARIZED_CONSTRAINT_CYCLES = 8
 
 
 # ---------------------------------------------------------------------------
@@ -75,6 +76,70 @@ def _evaluate_and_tell(
     backend.tell(cases)
 
 
+def _evaluate_metrics_and_tell(
+    backend: AxBackend,
+    metrics: list[Objective | ScalarizedObjective | Constraint],
+    cases: list[Case],
+) -> None:
+    """Evaluate all metric producers the backend expects, then tell Ax."""
+    for metric in metrics:
+        metric.batch_evaluate(cases)
+    backend.tell(cases)
+
+
+def _make_scalarized_constrained_backend(
+    seed: int,
+) -> tuple[AxBackend, list[Objective | ScalarizedObjective | Constraint]]:
+    backend = AxBackend()
+    backend.random_seed = seed
+    backend.initialization_trials = 3
+
+    def _read(case, key):
+        return float(case.read_metadata()["optimizer-suggestion"][key]["value"])
+
+    lift_penalty = Objective(
+        name="lift_penalty",
+        minimize=True,
+        objective_function=lambda case: (_read(case, "x") - 1.0) ** 2,
+    )
+    drag = Objective(
+        name="drag",
+        minimize=True,
+        objective_function=lambda case: (_read(case, "y") + 0.5) ** 2,
+    )
+    scalarized = ScalarizedObjective(
+        name="score",
+        minimize=True,
+        objectives=[lift_penalty, drag],
+        weights=[0.6, 0.4],
+    )
+    pressure = Constraint(
+        name="pressure",
+        objective_function=lambda case: _read(case, "x") + _read(case, "y"),
+        gte=-1.0,
+    )
+
+    dims = [
+        Dimension.range(
+            name="x",
+            link=DictionaryLink("constant/setup").entry("x"),
+            lower=-3.0,
+            upper=3.0,
+        ),
+        Dimension.range(
+            name="y",
+            link=DictionaryLink("constant/setup").entry("y"),
+            lower=-3.0,
+            upper=3.0,
+        ),
+    ]
+
+    backend.set_search_space(dims)
+    backend.set_objectives(scalarized)
+    backend.set_constraints([pressure])
+    return backend, [scalarized, pressure]
+
+
 def _run_replayed(
     tmp_path,
     prefix: str,
@@ -106,6 +171,35 @@ def _run_replayed(
     return suggestions
 
 
+def _run_replayed_with_metrics(
+    tmp_path,
+    prefix: str,
+    make_backend_fn,
+    make_case_fn,
+    seed: int = SEED,
+    n_cycles: int = N_CYCLES,
+) -> list[dict[str, float]]:
+    all_cases: list[Case] = []
+    suggestions: list[dict[str, float]] = []
+
+    for cycle in range(n_cycles):
+        backend, metrics = make_backend_fn(seed)
+        backend.initialize()
+
+        if all_cases:
+            _evaluate_metrics_and_tell(backend, metrics, all_cases)
+
+        suggestion = backend.ask(max_cases=1)[0]
+        params = {dim.name: value for dim, value in suggestion.items()}
+        suggestions.append(params)
+
+        case = make_case_fn(tmp_path, f"{prefix}-{cycle:02d}", params)
+        all_cases.append(case)
+        _evaluate_metrics_and_tell(backend, metrics, all_cases)
+
+    return suggestions
+
+
 def _run_continuous(
     tmp_path,
     prefix: str,
@@ -133,6 +227,32 @@ def _run_continuous(
     return suggestions
 
 
+def _run_continuous_with_metrics(
+    tmp_path,
+    prefix: str,
+    make_backend_fn,
+    make_case_fn,
+    seed: int = SEED,
+    n_cycles: int = N_CYCLES,
+) -> list[dict[str, float]]:
+    backend, metrics = make_backend_fn(seed)
+    backend.initialize()
+
+    all_cases: list[Case] = []
+    suggestions: list[dict[str, float]] = []
+
+    for cycle in range(n_cycles):
+        suggestion = backend.ask(max_cases=1)[0]
+        params = {dim.name: value for dim, value in suggestion.items()}
+        suggestions.append(params)
+
+        case = make_case_fn(tmp_path, f"{prefix}-{cycle:02d}", params)
+        all_cases.append(case)
+        _evaluate_metrics_and_tell(backend, metrics, all_cases)
+
+    return suggestions
+
+
 def _assert_suggestions_match(
     label_a: str,
     label_b: str,
@@ -141,6 +261,10 @@ def _assert_suggestions_match(
     *,
     abs_tol: float = 1e-12,
 ) -> None:
+    assert len(suggestions_a) == len(suggestions_b), (
+        f"{label_a} produced {len(suggestions_a)} suggestion(s), "
+        f"{label_b} produced {len(suggestions_b)}"
+    )
     for cycle, (a, b) in enumerate(zip(suggestions_a, suggestions_b)):
         for key in a:
             assert a[key] == pytest.approx(b[key], abs=abs_tol), (
@@ -174,6 +298,35 @@ def test_continuous_vs_replayed_determinism(tmp_path, make_suggestion_case):
     )
 
     _assert_suggestions_match("continuous", "replayed", continuous, replayed)
+
+
+def test_scalarized_constraint_continuous_vs_replayed_determinism(
+    tmp_path, make_suggestion_case
+):
+    """Replay determinism must hold for Ax-native scalarization plus an
+    OutcomeConstraint too, not only for a single plain objective.
+    """
+    continuous = _run_continuous_with_metrics(
+        tmp_path / "scalarized-cont",
+        "scalarized-cont",
+        _make_scalarized_constrained_backend,
+        make_suggestion_case,
+        n_cycles=SCALARIZED_CONSTRAINT_CYCLES,
+    )
+    replayed = _run_replayed_with_metrics(
+        tmp_path / "scalarized-replay",
+        "scalarized-replay",
+        _make_scalarized_constrained_backend,
+        make_suggestion_case,
+        n_cycles=SCALARIZED_CONSTRAINT_CYCLES,
+    )
+
+    _assert_suggestions_match(
+        "scalarized-continuous",
+        "scalarized-replayed",
+        continuous,
+        replayed,
+    )
 
 
 def test_different_seeds_diverge(tmp_path):

--- a/tests/flowboost/optimizer/test_mobo_acceptance.py
+++ b/tests/flowboost/optimizer/test_mobo_acceptance.py
@@ -1,0 +1,192 @@
+"""Aggregate MOBO acceptance tests.
+
+These tests intentionally live at the optimizer layer, not the session layer.
+They check whether Ax-backed MOBO adds value over a Sobol-only baseline on a
+cheap analytic multi-objective problem. Session tests should prove FlowBoost's
+orchestration contracts; this file is the slower canary for optimizer quality.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from statistics import median
+from typing import Callable
+
+import pytest
+
+from flowboost.openfoam.case import Case
+from flowboost.openfoam.dictionary import DictionaryLink
+from flowboost.optimizer.interfaces.Ax import AxBackend
+from flowboost.optimizer.objectives import Objective
+from flowboost.optimizer.search_space import Dimension
+
+
+SEEDS = (7, 13, 29)
+BUDGET = 14
+N_INIT = 5
+REFERENCE_POINT = (0.70, 0.70)
+
+
+def _read(case: Case, key: str) -> float:
+    metadata = case.read_metadata()
+    assert metadata is not None
+    return float(metadata["optimizer-suggestion"][key]["value"])
+
+
+def _pareto_ribbon_objectives() -> tuple[Objective, Objective]:
+    """Two minimized objectives with known Pareto ribbon y=0.5, x in [0.25, 0.75]."""
+
+    f_left = Objective(
+        name="f_left",
+        minimize=True,
+        threshold=REFERENCE_POINT[0],
+        objective_function=lambda case: (
+            (_read(case, "x") - 0.25) ** 2 + 0.10 * (_read(case, "y") - 0.50) ** 2
+        ),
+    )
+    f_right = Objective(
+        name="f_right",
+        minimize=True,
+        threshold=REFERENCE_POINT[1],
+        objective_function=lambda case: (
+            (_read(case, "x") - 0.75) ** 2 + 0.10 * (_read(case, "y") - 0.50) ** 2
+        ),
+    )
+    return f_left, f_right
+
+
+def _make_backend(
+    seed: int, initialization_trials: int
+) -> tuple[AxBackend, list[Objective]]:
+    backend = AxBackend()
+    backend.random_seed = seed
+    backend.initialization_trials = initialization_trials
+    objectives = list(_pareto_ribbon_objectives())
+    backend.set_objectives(objectives)
+    backend.set_search_space(
+        [
+            Dimension.range(
+                name="x",
+                link=DictionaryLink("constant/setup").entry("x"),
+                lower=0.0,
+                upper=1.0,
+            ),
+            Dimension.range(
+                name="y",
+                link=DictionaryLink("constant/setup").entry("y"),
+                lower=0.0,
+                upper=1.0,
+            ),
+        ]
+    )
+    backend.initialize()
+    return backend, objectives
+
+
+def _non_dominated(points: list[tuple[float, float]]) -> list[tuple[float, float]]:
+    non_dominated = []
+    for i, candidate in enumerate(points):
+        c_left, c_right = candidate
+        dominated = False
+        for j, other in enumerate(points):
+            if i == j:
+                continue
+            o_left, o_right = other
+            if (
+                o_left <= c_left
+                and o_right <= c_right
+                and (o_left < c_left or o_right < c_right)
+            ):
+                dominated = True
+                break
+        if not dominated:
+            non_dominated.append(candidate)
+    return non_dominated
+
+
+def _hypervolume_2d_minimize(
+    points: list[tuple[float, float]], reference: tuple[float, float]
+) -> float:
+    """Exact dominated hypervolume for 2D minimization."""
+
+    bounded = [
+        (left, right)
+        for left, right in _non_dominated(points)
+        if left < reference[0] and right < reference[1]
+    ]
+    hv = 0.0
+    best_right = reference[1]
+    for left, right in sorted(bounded):
+        if right < best_right:
+            hv += (reference[0] - left) * (best_right - right)
+            best_right = right
+    return hv
+
+
+def _run_campaign(
+    tmp_path: Path,
+    make_suggestion_case: Callable[[Path, str, dict], Case],
+    *,
+    seed: int,
+    initialization_trials: int,
+    label: str,
+) -> float:
+    backend, objectives = _make_backend(seed, initialization_trials)
+    cases: list[Case] = []
+    outputs: list[tuple[float, float]] = []
+    case_parent = tmp_path / label / f"seed-{seed}"
+
+    for cycle in range(BUDGET):
+        suggestion = backend.ask(max_cases=1)[0]
+        params = {dim.name: value for dim, value in suggestion.items()}
+        case = make_suggestion_case(case_parent, f"trial-{cycle:02d}", params)
+        cases.append(case)
+
+        for objective in objectives:
+            objective.batch_evaluate(cases)
+        backend.tell(cases)
+
+        left = objectives[0].data_for_case(case)
+        right = objectives[1].data_for_case(case)
+        assert left is not None and right is not None
+        outputs.append((left, right))
+
+    return _hypervolume_2d_minimize(outputs, REFERENCE_POINT)
+
+
+@pytest.mark.slow
+def test_mobo_beats_sobol_baseline_on_pareto_ribbon(tmp_path, make_suggestion_case):
+    """MOBO should beat a same-budget Sobol-only baseline in aggregate.
+
+    This is deliberately statistical rather than seed-exact. A single Ax/BoTorch
+    seed may move around after dependency updates; the median across seeds should
+    still show that post-Sobol acquisitions use the observations productively.
+    """
+
+    mobo_hv = [
+        _run_campaign(
+            tmp_path,
+            make_suggestion_case,
+            seed=seed,
+            initialization_trials=N_INIT,
+            label="mobo",
+        )
+        for seed in SEEDS
+    ]
+    sobol_hv = [
+        _run_campaign(
+            tmp_path,
+            make_suggestion_case,
+            seed=seed,
+            initialization_trials=BUDGET,
+            label="sobol",
+        )
+        for seed in SEEDS
+    ]
+
+    median_mobo = median(mobo_hv)
+    median_sobol = median(sobol_hv)
+    assert median_mobo > median_sobol, (
+        "MOBO did not improve median dominated hypervolume over a Sobol-only "
+        f"baseline. mobo={mobo_hv}, sobol={sobol_hv}"
+    )

--- a/tests/flowboost/optimizer/test_objectives_unit.py
+++ b/tests/flowboost/optimizer/test_objectives_unit.py
@@ -9,13 +9,6 @@ from flowboost.optimizer.objectives import Objective, ScalarizedObjective
 
 
 @pytest.fixture
-def case(tmp_path):
-    d = tmp_path / "test_case"
-    d.mkdir()
-    return Case(d)
-
-
-@pytest.fixture
 def failed_case(tmp_path):
     d = tmp_path / "failed_case"
     d.mkdir()
@@ -129,6 +122,86 @@ class TestObjectiveExceptionPropagation:
         obj = Objective("test", minimize=True, objective_function=key_error_fn)
         with pytest.raises(KeyError):
             obj.evaluate(case)
+
+
+class TestObjectiveBounds:
+    def test_defaults_are_none(self):
+        obj = Objective("f", minimize=True, objective_function=lambda c: 1.0)
+        assert obj.gte is None
+        assert obj.lte is None
+        assert obj.has_bounds is False
+
+    def test_gte_only(self):
+        obj = Objective("f", minimize=True, objective_function=lambda c: 1.0, gte=0.5)
+        assert (obj.gte, obj.lte) == (0.5, None)
+        assert obj.has_bounds is True
+
+    def test_lte_only(self):
+        obj = Objective("f", minimize=True, objective_function=lambda c: 1.0, lte=9.0)
+        assert (obj.gte, obj.lte) == (None, 9.0)
+        assert obj.has_bounds is True
+
+    def test_both_bounds(self):
+        obj = Objective(
+            "f", minimize=True, objective_function=lambda c: 1.0, gte=0.0, lte=9.0
+        )
+        assert (obj.gte, obj.lte) == (0.0, 9.0)
+        assert obj.has_bounds is True
+
+    def test_bound_metric_name(self):
+        obj = Objective(
+            "drag", minimize=True, objective_function=lambda c: 1.0, lte=0.05
+        )
+        assert obj.bound_metric_name == "drag__bound"
+
+    def test_rejects_inverted_bounds(self):
+        with pytest.raises(ValueError, match="empty feasible range"):
+            Objective(
+                "f", minimize=True, objective_function=lambda c: 1.0, gte=10.0, lte=5.0
+            )
+
+    def test_rejects_single_point_bounds(self):
+        with pytest.raises(ValueError, match="single-point feasible range"):
+            Objective(
+                "f", minimize=True, objective_function=lambda c: 1.0, gte=5.0, lte=5.0
+            )
+
+    @pytest.mark.parametrize(
+        "bad_value",
+        [float("nan"), float("inf"), float("-inf")],
+        ids=["nan", "pos_inf", "neg_inf"],
+    )
+    def test_rejects_non_finite_gte(self, bad_value):
+        with pytest.raises(ValueError, match="must be a finite number"):
+            Objective(
+                "f", minimize=True, objective_function=lambda c: 1.0, gte=bad_value
+            )
+
+    @pytest.mark.parametrize(
+        "bad_value",
+        [float("nan"), float("inf"), float("-inf")],
+        ids=["nan", "pos_inf", "neg_inf"],
+    )
+    def test_rejects_non_finite_lte(self, bad_value):
+        with pytest.raises(ValueError, match="must be a finite number"):
+            Objective(
+                "f", minimize=True, objective_function=lambda c: 1.0, lte=bad_value
+            )
+
+    def test_metric_values_for_case_emits_bound_alias(self, case):
+        obj = Objective(
+            "drag", minimize=True, objective_function=lambda c: 0.04, lte=0.05
+        )
+        obj.evaluate(case)
+        # The bounded Objective contributes both its own metric and the
+        # derived bound tracking metric under the same value, so Ax's raw_data
+        # covers the tracking metric the OutcomeConstraint references.
+        assert obj.metric_values_for_case(case) == {"drag": 0.04, "drag__bound": 0.04}
+
+    def test_metric_values_for_case_without_bounds_is_unchanged(self, case):
+        obj = Objective("drag", minimize=True, objective_function=lambda c: 0.04)
+        obj.evaluate(case)
+        assert obj.metric_values_for_case(case) == {"drag": 0.04}
 
 
 class TestScalarizedObjective:
@@ -352,3 +425,16 @@ class TestScalarizedObjectiveInnerValidation:
         obj = Objective("solo", minimize=True, objective_function=lambda c: 1.0)
         with pytest.raises(ValueError, match="duplicate inner objective names"):
             ScalarizedObjective("agg", minimize=True, objectives=[obj, obj])
+
+    def test_bounded_inner_objective_accepted(self):
+        """Inner Objectives may carry bounds. The bound attaches to a derived
+        tracking metric on the same inner name, so Ax never sees a constraint
+        on an objective metric directly. Semantics: 'optimize the scalarized
+        sum, subject to inner_a being within its bound'."""
+        objs = [
+            Objective("a", minimize=True, objective_function=lambda c: 1.0, lte=0.5),
+            Objective("b", minimize=True, objective_function=lambda c: 2.0),
+        ]
+        agg = ScalarizedObjective("agg", minimize=True, objectives=objs)
+        assert agg.objectives[0].has_bounds is True
+        assert agg.objectives[0].bound_metric_name == "a__bound"

--- a/tests/flowboost/session/test_session_unit.py
+++ b/tests/flowboost/session/test_session_unit.py
@@ -1,5 +1,7 @@
 """Unit tests for Session logic that doesn't require OpenFOAM."""
 
+import json
+import shutil
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -7,8 +9,10 @@ import pytest
 
 from flowboost.manager.manager import JobV2
 from flowboost.openfoam.case import Case
+from flowboost.openfoam.dictionary import DictionaryLink
 from flowboost.optimizer.backend import OptimizationComplete
-from flowboost.optimizer.objectives import Objective
+from flowboost.optimizer.objectives import Constraint, Objective, ScalarizedObjective
+from flowboost.optimizer.search_space import Dimension
 from flowboost.session.session import Session
 
 
@@ -74,10 +78,40 @@ class TestGetNextJobNumber:
         assert session._get_next_job_number() == 3
 
 
+class TestSessionOptimizationConfiguration:
+    def test_configure_optimization_delegates_to_backend(self, tmp_path):
+        session = Session(name="test", data_dir=tmp_path / "session")
+        objective = Objective("score", minimize=True, objective_function=lambda c: 1.0)
+        constraint = Constraint("pressure", objective_function=lambda c: 0.5, gte=0.0)
+        dimension = Dimension.range(
+            name="x",
+            link=DictionaryLink("constant/setup").entry("x"),
+            lower=0.0,
+            upper=1.0,
+        )
+
+        configured = session.configure_optimization(
+            objectives=objective,
+            constraints=constraint,
+            search_space=dimension,
+        )
+
+        assert configured is session
+        assert session.backend.objectives == [objective]
+        assert session.backend.constraints == [constraint]
+        assert session.backend.dimensions == [dimension]
+
+
 class TestCheckTerminationCriteria:
     def _make_session_with_cases(self, tmp_path, n_cases, **session_kwargs):
         session = Session(name="test", data_dir=tmp_path / "session", **session_kwargs)
-        obj = Objective("score", minimize=True, objective_function=lambda c: 1.0)
+        obj = Objective(
+            "score",
+            minimize=True,
+            objective_function=lambda c: float(
+                c.read_metadata()["optimizer-suggestion"]["score"]["value"]
+            ),
+        )
         session.backend.set_objectives([obj])
 
         for i in range(n_cases):
@@ -86,12 +120,8 @@ class TestCheckTerminationCriteria:
             case.success = True
             case.persist_to_file()
             case.update_metadata(
-                {"score": {"value": float(i), "minimize": True}},
-                entry_header="objective-outputs",
-            )
-            case.update_metadata(
-                {"score": float(i)},
-                entry_header="objective-values-raw",
+                {"score": {"value": float(i)}},
+                entry_header="optimizer-suggestion",
             )
 
         return session
@@ -104,6 +134,15 @@ class TestCheckTerminationCriteria:
         session = self._make_session_with_cases(tmp_path, n_cases=2, max_evaluations=5)
         assert session._check_termination_criteria() is False
 
+    def test_max_evaluations_counts_failed_cases(self, tmp_path):
+        session = self._make_session_with_cases(tmp_path, n_cases=1, max_evaluations=2)
+
+        failed_case = Case(_make_foam_dir(session.archival_dir / "job_00001_failed"))
+        failed_case.success = False
+        failed_case.persist_to_file()
+
+        assert session._check_termination_criteria() is True
+
     def test_no_criteria_returns_false(self, tmp_path):
         session = self._make_session_with_cases(tmp_path, n_cases=3)
         assert session._check_termination_criteria() is False
@@ -115,7 +154,7 @@ class TestCheckTerminationCriteria:
 
     def test_target_value_minimize_not_reached(self, tmp_path):
         session = self._make_session_with_cases(tmp_path, n_cases=1, target_value=-1.0)
-        # Case 0 has value=0.0 which is > -1.0
+        # Case 0 re-evaluates to value=0.0, which is > -1.0
         assert session._check_termination_criteria() is False
 
     def test_target_value_maximize(self, tmp_path):
@@ -146,6 +185,69 @@ class TestCheckTerminationCriteria:
             target_objective="nonexistent",
         )
         assert session._check_termination_criteria() is False
+
+
+class TestWriteDesignsLog:
+    def test_preserves_bounded_objective_metadata(self, tmp_path):
+        session = Session(name="test", data_dir=tmp_path / "session")
+        session.backend.set_objectives(
+            [
+                Objective(
+                    "drag",
+                    minimize=True,
+                    objective_function=lambda c: 0.04,
+                    gte=0.01,
+                    lte=0.05,
+                )
+            ]
+        )
+
+        case = Case(_make_foam_dir(session.archival_dir / "job_00000_abc"))
+        case.success = True
+        case.persist_to_file()
+
+        session._write_designs_log()
+
+        log = json.loads((session.data_dir / "designs.json").read_text())
+        objective = log["designs"][0]["objectives"]["drag"]
+        assert objective["value"] == pytest.approx(0.04)
+        assert objective["minimize"] is True
+        assert objective["gte"] == pytest.approx(0.01)
+        assert objective["lte"] == pytest.approx(0.05)
+
+    def test_preserves_scalarized_component_bounds(self, tmp_path):
+        session = Session(name="test", data_dir=tmp_path / "session")
+        drag = Objective(
+            "drag",
+            minimize=True,
+            objective_function=lambda c: 0.04,
+            lte=0.05,
+        )
+        mass = Objective("mass", minimize=True, objective_function=lambda c: 1.0)
+        session.backend.set_objectives(
+            ScalarizedObjective(
+                "ratio",
+                minimize=True,
+                objectives=[drag, mass],
+                weights=[1.0, 1.0],
+            )
+        )
+
+        case = Case(_make_foam_dir(session.archival_dir / "job_00000_abc"))
+        case.success = True
+        case.persist_to_file()
+
+        session._write_designs_log()
+
+        log = json.loads((session.data_dir / "designs.json").read_text())
+        ratio = log["designs"][0]["objectives"]["ratio"]
+        assert ratio["is_scalarized"] is True
+        assert ratio["value"] == pytest.approx(1.04)
+        assert ratio["component_bounds"] == {"drag": {"lte": 0.05}}
+        assert ratio["components"]["drag"]["value"] == pytest.approx(0.04)
+        assert ratio["components"]["drag"]["minimize"] is True
+        assert ratio["components"]["mass"]["value"] == pytest.approx(1.0)
+        assert ratio["components"]["mass"]["minimize"] is True
 
 
 class TestPersistentOptimizationFailureHandling:
@@ -230,3 +332,196 @@ class TestPersistentOptimizationFailureHandling:
 
         assert post_updates == [finished_job.to_dict()]
         assert manager.finalized_jobs == [finished_job]
+
+    def test_finished_job_preserves_pending_case_metadata(self, tmp_path, monkeypatch):
+        session = Session(name="test", data_dir=tmp_path / "session")
+        finished_job = JobV2(
+            id="123",
+            name="flwbst_job_00001_abc",
+            wdir=session.pending_dir / "job_00001_abc",
+        )
+        case = Case(_make_foam_dir(finished_job.wdir))
+        case._generation_index = "00001.01"
+        case._based_on_case = tmp_path / "template"
+        case._execution_environment = "unit-test"
+        case._model_predictions_by_objective = {"drag": {"mean": 1.23, "sem": 0.1}}
+        case.persist_to_file()
+        case.update_metadata(
+            {"x": {"value": 0.5}},
+            entry_header="optimizer-suggestion",
+        )
+
+        manager = RecordingJobManager(
+            do_monitoring_result=(1, [finished_job], False), move_result=True
+        )
+        session.job_manager = manager
+
+        def move_data_for_job(job: JobV2, dest: Path) -> bool:
+            shutil.move(str(job.wdir), str(dest))
+            return True
+
+        manager.move_data_for_job = move_data_for_job
+        monkeypatch.setattr(session, "print_top_designs", lambda n=5: None)
+        monkeypatch.setattr(session, "_check_termination_criteria", lambda: False)
+        monkeypatch.setattr(
+            session,
+            "loop_optimizer_once",
+            lambda num_new_cases: (_ for _ in ()).throw(OptimizationComplete("done")),
+        )
+        monkeypatch.setattr(session, "_write_designs_log", lambda: None)
+
+        session.persistent_optimization()
+
+        archived = Case.try_restoring(session.archival_dir / finished_job.wdir.name)
+        assert archived._generation_index == "00001.01"
+        assert archived._based_on_case == tmp_path / "template"
+        assert archived._execution_environment == "unit-test"
+        assert archived._model_predictions_by_objective == {
+            "drag": {"mean": 1.23, "sem": 0.1}
+        }
+
+        metadata = archived.read_metadata()
+        assert metadata["generation_index"] == "00001.01"
+        assert metadata["optimizer-suggestion"] == {"x": {"value": 0.5}}
+
+    def test_caps_new_cases_to_remaining_max_evaluations(self, tmp_path, monkeypatch):
+        session = Session(name="test", data_dir=tmp_path / "session", max_evaluations=3)
+        for i in range(2):
+            case = Case(_make_foam_dir(session.archival_dir / f"job_0000{i}_abc"))
+            case.success = True
+            case.persist_to_file()
+
+        manager = RecordingJobManager()
+        manager.job_limit = 2
+        session.job_manager = manager
+
+        monitoring_calls = 0
+
+        def do_monitoring():
+            nonlocal monitoring_calls
+            monitoring_calls += 1
+            if monitoring_calls == 1:
+                return (2, [], False)
+
+            pending = session.get_pending_cases()
+            assert len(pending) == 1
+            return (
+                1,
+                [
+                    JobV2(
+                        id="456",
+                        name=f"flwbst_{pending[0].name}",
+                        wdir=pending[0].path,
+                    )
+                ],
+                False,
+            )
+
+        def move_data_for_job(job: JobV2, dest: Path) -> bool:
+            shutil.move(str(job.wdir), str(dest))
+            return True
+
+        requested_new_cases: list[int] = []
+
+        def loop_optimizer_once(num_new_cases: int):
+            requested_new_cases.append(num_new_cases)
+            assert num_new_cases == 1
+            return [Case(_make_foam_dir(session.pending_dir / "job_00002_abc"))]
+
+        manager.do_monitoring = do_monitoring
+        manager.move_data_for_job = move_data_for_job
+        monkeypatch.setattr(session, "print_top_designs", lambda n=5: None)
+        monkeypatch.setattr(session, "_write_designs_log", lambda: None)
+        monkeypatch.setattr(session, "loop_optimizer_once", loop_optimizer_once)
+
+        session.persistent_optimization()
+
+        assert requested_new_cases == [1]
+        assert [case.name for case in manager.submitted_cases] == ["job_00002_abc"]
+        assert len(session.get_finished_cases(include_failed=True)) == 3
+
+    def test_waits_when_max_evaluation_budget_is_pending(self, tmp_path, monkeypatch):
+        session = Session(name="test", data_dir=tmp_path / "session", max_evaluations=3)
+        for i in range(2):
+            case = Case(_make_foam_dir(session.archival_dir / f"job_0000{i}_abc"))
+            case.success = True
+            case.persist_to_file()
+
+        pending = Case(_make_foam_dir(session.pending_dir / "job_00002_abc"))
+        pending.persist_to_file()
+
+        manager = RecordingJobManager()
+        manager.job_limit = 2
+        session.job_manager = manager
+
+        monitoring_calls = 0
+
+        def do_monitoring():
+            nonlocal monitoring_calls
+            monitoring_calls += 1
+            if monitoring_calls == 1:
+                return (1, [], False)
+
+            return (
+                1,
+                [
+                    JobV2(
+                        id="456",
+                        name=f"flwbst_{pending.name}",
+                        wdir=pending.path,
+                    )
+                ],
+                False,
+            )
+
+        def move_data_for_job(job: JobV2, dest: Path) -> bool:
+            shutil.move(str(job.wdir), str(dest))
+            return True
+
+        manager.do_monitoring = do_monitoring
+        manager.move_data_for_job = move_data_for_job
+        monkeypatch.setattr(session, "print_top_designs", lambda n=5: None)
+        monkeypatch.setattr(session, "_write_designs_log", lambda: None)
+        monkeypatch.setattr(
+            session,
+            "loop_optimizer_once",
+            lambda num_new_cases: pytest.fail(
+                f"unexpected acquisition request for {num_new_cases} cases"
+            ),
+        )
+
+        session.persistent_optimization()
+
+        assert manager.submitted_cases == []
+        assert len(session.get_finished_cases(include_failed=True)) == 3
+
+    def test_failed_cases_consume_remaining_evaluation_budget(
+        self, tmp_path, monkeypatch
+    ):
+        session = Session(name="test", data_dir=tmp_path / "session", max_evaluations=2)
+
+        successful = Case(_make_foam_dir(session.archival_dir / "job_00000_abc"))
+        successful.success = True
+        successful.persist_to_file()
+
+        failed = Case(_make_foam_dir(session.archival_dir / "job_00001_failed"))
+        failed.success = False
+        failed.persist_to_file()
+
+        manager = RecordingJobManager()
+        manager.job_limit = 2
+        session.job_manager = manager
+
+        monkeypatch.setattr(session, "print_top_designs", lambda n=5: None)
+        monkeypatch.setattr(session, "_write_designs_log", lambda: None)
+        monkeypatch.setattr(
+            session,
+            "loop_optimizer_once",
+            lambda num_new_cases: pytest.fail(
+                f"unexpected acquisition request for {num_new_cases} cases"
+            ),
+        )
+
+        session.persistent_optimization()
+
+        assert manager.submitted_cases == []

--- a/tests/flowboost/session/test_synthetic_openfoam_campaign.py
+++ b/tests/flowboost/session/test_synthetic_openfoam_campaign.py
@@ -1,0 +1,812 @@
+"""Synthetic OpenFOAM campaign tests.
+
+These tests intentionally build a tiny OpenFOAM-shaped world instead of
+mocking the FlowBoost stack. A test-local ``foamDictionary`` executable edits
+JSON-backed "dictionaries", and a case-local ``Allrun`` script acts as a
+deterministic synthetic solver that writes OpenFOAM-style postProcessing data.
+
+The goal is to validate the contracts that matter during long campaigns:
+dictionary links are resolved and written, cases are cloned, jobs are submitted
+through the real Manager API, results are read through Case.data, objectives
+and constraints are replayed into Ax, metadata survives designs.json export,
+and a session can be closed with pending jobs and restored later.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import shlex
+import sys
+from itertools import count
+from pathlib import Path
+from typing import Any
+
+import polars as pl
+import pytest
+
+from flowboost.manager.manager import Manager
+from flowboost.openfoam.case import Case
+from flowboost.openfoam.dictionary import Dictionary
+from flowboost.openfoam.runtime import reset_runtime
+from flowboost.optimizer.objectives import Constraint, Objective, ScalarizedObjective
+from flowboost.optimizer.search_space import Dimension
+from flowboost.session.session import Session
+
+pytestmark = pytest.mark.slow
+
+MAX_EVALUATIONS = 8
+JOB_LIMIT = 1
+RANDOM_SEED = 17
+INITIALIZATION_TRIALS = 4
+RESTORE_INTERRUPT_AFTER_COMPLETED = INITIALIZATION_TRIALS + 1
+PARETO_MAX_EVALUATIONS = 18
+PARETO_INITIALIZATION_TRIALS = 5
+PARETO_SEED = 29
+
+
+def _install_synthetic_foam_dictionary(tmp_path: Path, monkeypatch) -> None:
+    """Install a small foamDictionary-compatible CLI on PATH.
+
+    The script supports the subset FlowBoost needs in this campaign:
+    ``-keywords``, ``-keywords -entry ...``, ``-entry ... -value``, and
+    ``-entry ... -set ...``.
+    """
+    bin_dir = tmp_path / "synthetic_bin"
+    bin_dir.mkdir()
+    foam_dictionary = bin_dir / "foamDictionary"
+    foam_dictionary.write_text(
+        """#!/usr/bin/env python3
+import json
+import sys
+from pathlib import Path
+
+
+def parse_scalar(raw):
+    raw = str(raw).strip()
+    if raw.lower() in {"true", "false"}:
+        return raw.lower() == "true"
+    try:
+        if any(ch in raw for ch in ".eE"):
+            return float(raw)
+        return int(raw)
+    except ValueError:
+        return raw
+
+
+def format_scalar(value):
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)
+
+
+def resolve(data, entry_path):
+    node = data
+    if not entry_path:
+        return node
+    for part in entry_path.split("/"):
+        node = node[part]
+    return node
+
+
+def assign(data, entry_path, value):
+    parts = entry_path.split("/")
+    node = data
+    for part in parts[:-1]:
+        node = node[part]
+    node[parts[-1]] = value
+
+
+args = sys.argv[1:]
+if not args:
+    print("missing dictionary path", file=sys.stderr)
+    sys.exit(2)
+
+path = Path(args[0])
+data = json.loads(path.read_text())
+
+try:
+    if "-keywords" in args:
+        entry = args[args.index("-entry") + 1] if "-entry" in args else ""
+        node = resolve(data, entry)
+        if isinstance(node, dict):
+            print("\\n".join(node.keys()))
+            sys.exit(0)
+        print(f"'{entry}' is a leaf entry", file=sys.stderr)
+        sys.exit(0)
+
+    if "-value" in args:
+        entry = args[args.index("-entry") + 1]
+        print(format_scalar(resolve(data, entry)))
+        sys.exit(0)
+
+    if "-set" in args:
+        entry = args[args.index("-entry") + 1]
+        value = parse_scalar(args[args.index("-set") + 1])
+        assign(data, entry, value)
+        path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\\n")
+        sys.exit(0)
+except (KeyError, IndexError) as exc:
+    print(f"foamDictionary synthetic error: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+print(f"unsupported foamDictionary invocation: {args}", file=sys.stderr)
+sys.exit(2)
+""",
+    )
+    foam_dictionary.chmod(0o755)
+
+    monkeypatch.setenv("FOAM_INST_DIR", str(tmp_path / "synthetic-openfoam"))
+    monkeypatch.setenv("FLOWBOOST_FOAM_MODE", "native")
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ['PATH']}")
+    reset_runtime()
+
+
+def _reset_session_case_ids(monkeypatch) -> None:
+    ids = count(1)
+    monkeypatch.setattr(
+        "flowboost.session.session.unique_id",
+        lambda hashable=None: f"{next(ids):08x}",
+    )
+
+
+def _disable_progress_tables(session: Session) -> None:
+    # Progress table rendering is not part of these campaign contracts.
+    session.print_top_designs = lambda n=5, by_objective=None: None
+
+
+def _create_synthetic_template(root: Path) -> Case:
+    template = root / "synthetic_airfoil_template"
+    (template / "constant").mkdir(parents=True)
+    (template / "system").mkdir()
+    (template / "constant" / "design").write_text(
+        json.dumps(
+            {
+                "alpha": 0.0,
+                "camber": 0.04,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    )
+    (template / "system" / "controlDict").write_text("{}\n")
+
+    python = shlex.quote(sys.executable)
+    (template / "Allrun").write_text(
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+
+{python} - <<'PY'
+import json
+from pathlib import Path
+
+case = Path.cwd()
+design = json.loads((case / "constant" / "design").read_text())
+alpha = float(design["alpha"])
+camber = float(design["camber"])
+
+# A small analytic airfoil surrogate with a known feasible basin. The numbers
+# are not physical constants; they are shaped to create realistic trade-offs:
+# lift likes alpha/camber, drag penalizes moving away from a sweet spot, and
+# pressure recovery/stability bound the useful region.
+separation = max(0.0, alpha - (4.8 + 18.0 * camber))
+lift = (
+    1.02
+    + 0.105 * alpha
+    + 2.6 * camber
+    - 0.010 * (alpha - 3.0) ** 2
+    - 0.16 * separation**2
+)
+drag = (
+    0.032
+    + 0.0045 * (alpha - 2.6) ** 2
+    + 5.5 * (camber - 0.055) ** 2
+    + 0.020 * separation**2
+)
+pressure_recovery = 0.78 - 0.018 * (alpha - 1.8) ** 2 - 1.4 * (camber - 0.045) ** 2
+stability_margin = 0.145 + 0.95 * camber - 0.018 * alpha
+
+out_dir = case / "postProcessing" / "syntheticAero" / "0"
+out_dir.mkdir(parents=True, exist_ok=True)
+(out_dir / "coefficients.dat").write_text(
+    "# Time\\tlift\\tdrag\\tpressure_recovery\\tstability_margin\\tseparation\\n"
+    f"0\\t{{lift:.12f}}\\t{{drag:.12f}}\\t{{pressure_recovery:.12f}}\\t"
+    f"{{stability_margin:.12f}}\\t{{separation:.12f}}\\n"
+    f"1\\t{{lift:.12f}}\\t{{drag:.12f}}\\t{{pressure_recovery:.12f}}\\t"
+    f"{{stability_margin:.12f}}\\t{{separation:.12f}}\\n"
+)
+PY
+""",
+    )
+
+    return Case(template)
+
+
+def _create_pareto_ribbon_template(root: Path) -> Case:
+    template = root / "synthetic_pareto_template"
+    (template / "constant").mkdir(parents=True)
+    (template / "system").mkdir()
+    (template / "constant" / "design").write_text(
+        json.dumps({"x": 0.5, "y": 0.5}, indent=2, sort_keys=True) + "\n"
+    )
+    (template / "system" / "controlDict").write_text("{}\n")
+
+    python = shlex.quote(sys.executable)
+    (template / "Allrun").write_text(
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+
+{python} - <<'PY'
+import json
+from pathlib import Path
+
+case = Path.cwd()
+design = json.loads((case / "constant" / "design").read_text())
+x = float(design["x"])
+y = float(design["y"])
+
+# True MOO target: two minimized objectives with an analytic Pareto ribbon:
+# x in [0.25, 0.75], y = 0.50. Any point off y=0.50 is dominated by its
+# projection onto the ribbon; moving along x trades f_left against f_right.
+f_left = (x - 0.25) ** 2 + 0.10 * (y - 0.50) ** 2
+f_right = (x - 0.75) ** 2 + 0.10 * (y - 0.50) ** 2
+
+# Alternate landscape used only to prove the post-Sobol BO phase consumes
+# observations. Same search space and same solver output shape, different
+# objective functions.
+alt_left = (x - 0.12) ** 2 + (y - 0.88) ** 2
+alt_right = (x - 0.88) ** 2 + (y - 0.12) ** 2
+
+stability = 1.0 - 4.0 * (y - 0.50) ** 2
+
+out_dir = case / "postProcessing" / "paretoRibbon" / "0"
+out_dir.mkdir(parents=True, exist_ok=True)
+(out_dir / "objectives.dat").write_text(
+    "# Time\\tf_left\\tf_right\\talt_left\\talt_right\\tstability\\n"
+    f"0\\t{{f_left:.12f}}\\t{{f_right:.12f}}\\t{{alt_left:.12f}}\\t"
+    f"{{alt_right:.12f}}\\t{{stability:.12f}}\\n"
+    f"1\\t{{f_left:.12f}}\\t{{f_right:.12f}}\\t{{alt_left:.12f}}\\t"
+    f"{{alt_right:.12f}}\\t{{stability:.12f}}\\n"
+)
+PY
+""",
+    )
+
+    return Case(template)
+
+
+def _last_metric_from(
+    case: Case, function_object_name: str, metric_name: str
+) -> float | None:
+    frame = case.data.simple_function_object_reader(function_object_name)
+    if frame is None or frame.is_empty():
+        return None
+    assert isinstance(frame, pl.DataFrame)
+    return float(frame.select(pl.last(metric_name)).item())
+
+
+def _last_metric(case: Case, metric_name: str) -> float | None:
+    return _last_metric_from(case, "syntheticAero", metric_name)
+
+
+def _last_pareto_metric(case: Case, metric_name: str) -> float | None:
+    return _last_metric_from(case, "paretoRibbon", metric_name)
+
+
+def _configure_synthetic_session(
+    session: Session, template: Case | None = None
+) -> None:
+    if template is not None:
+        session.attach_template_case(template)
+
+    lift = Objective(
+        name="lift",
+        minimize=False,
+        objective_function=lambda case: _last_metric(case, "lift"),
+    )
+    drag = Objective(
+        name="drag",
+        minimize=True,
+        objective_function=lambda case: _last_metric(case, "drag"),
+        lte=0.080,
+    )
+    score = ScalarizedObjective(
+        name="aero_score",
+        minimize=False,
+        objectives=[lift, drag],
+        weights=[0.75, -0.25],
+    )
+    pressure = Constraint(
+        name="pressure_recovery",
+        objective_function=lambda case: _last_metric(case, "pressure_recovery"),
+        gte=0.58,
+    )
+    stability = Constraint(
+        name="stability_margin",
+        objective_function=lambda case: _last_metric(case, "stability_margin"),
+        gte=0.08,
+    )
+
+    session.backend.random_seed = RANDOM_SEED
+    session.backend.initialization_trials = INITIALIZATION_TRIALS
+    session.configure_optimization(
+        objectives=score,
+        constraints=[pressure, stability],
+        search_space=[
+            Dimension.range(
+                name="alpha",
+                link=Dictionary.link("constant/design").entry("alpha"),
+                lower=-2.0,
+                upper=6.0,
+            ),
+            Dimension.range(
+                name="camber",
+                link=Dictionary.link("constant/design").entry("camber"),
+                lower=0.00,
+                upper=0.10,
+            ),
+        ],
+    )
+
+    if session.job_manager is None:
+        session.job_manager = Manager.create(
+            scheduler="Local",
+            wdir=session.data_dir,
+            job_limit=JOB_LIMIT,
+        )
+    session.job_manager.monitoring_interval = 0.01
+    _disable_progress_tables(session)
+    session.persist()
+
+
+def _configure_pareto_session(
+    session: Session,
+    template: Case | None = None,
+    *,
+    objective_variant: str = "normal",
+) -> None:
+    if template is not None:
+        session.attach_template_case(template)
+
+    if objective_variant == "normal":
+        left_metric = "f_left"
+        right_metric = "f_right"
+    elif objective_variant == "alternate":
+        left_metric = "alt_left"
+        right_metric = "alt_right"
+    else:
+        raise ValueError(f"Unknown Pareto objective variant: {objective_variant}")
+
+    f_left = Objective(
+        name="f_left",
+        minimize=True,
+        threshold=0.70,
+        objective_function=lambda case: _last_pareto_metric(case, left_metric),
+    )
+    f_right = Objective(
+        name="f_right",
+        minimize=True,
+        threshold=0.70,
+        objective_function=lambda case: _last_pareto_metric(case, right_metric),
+    )
+    stability = Constraint(
+        name="stability",
+        objective_function=lambda case: _last_pareto_metric(case, "stability"),
+        gte=0.85,
+    )
+
+    session.backend.random_seed = PARETO_SEED
+    session.backend.initialization_trials = PARETO_INITIALIZATION_TRIALS
+    session.configure_optimization(
+        objectives=[f_left, f_right],
+        constraints=[stability],
+        search_space=[
+            Dimension.range(
+                name="x",
+                link=Dictionary.link("constant/design").entry("x"),
+                lower=0.0,
+                upper=1.0,
+            ),
+            Dimension.range(
+                name="y",
+                link=Dictionary.link("constant/design").entry("y"),
+                lower=0.0,
+                upper=1.0,
+            ),
+        ],
+    )
+
+    if session.job_manager is None:
+        session.job_manager = Manager.create(
+            scheduler="Local",
+            wdir=session.data_dir,
+            job_limit=JOB_LIMIT,
+        )
+    session.job_manager.monitoring_interval = 0.01
+    _disable_progress_tables(session)
+    session.persist()
+
+
+def _design_parameters(designs: list[dict[str, Any]]) -> list[dict[str, float]]:
+    return [
+        {
+            "alpha": float(design["parameters"]["alpha"]),
+            "camber": float(design["parameters"]["camber"]),
+        }
+        for design in designs
+    ]
+
+
+def _xy_parameters(designs: list[dict[str, Any]]) -> list[dict[str, float]]:
+    return [
+        {
+            "x": float(design["parameters"]["x"]),
+            "y": float(design["parameters"]["y"]),
+        }
+        for design in designs
+    ]
+
+
+def _load_designs(session_dir: Path) -> list[dict[str, Any]]:
+    payload = json.loads((session_dir / "designs.json").read_text())
+    assert payload["num_designs"] == len(payload["designs"])
+    return payload["designs"]
+
+
+def _finite_value(metric: dict[str, Any], label: str) -> float:
+    assert "value" in metric, f"{label} missing value"
+    assert metric["value"] is not None, f"{label} value is None"
+    value = float(metric["value"])
+    assert math.isfinite(value), f"{label} value is not finite: {value}"
+    return value
+
+
+def _objective_value(design: dict[str, Any], name: str) -> float:
+    return _finite_value(
+        design["objectives"][name], f"{design['name']} objective {name}"
+    )
+
+
+def _constraint_value(design: dict[str, Any], name: str) -> float:
+    return _finite_value(
+        design["constraints"][name], f"{design['name']} constraint {name}"
+    )
+
+
+def _component_value(design: dict[str, Any], objective: str, component: str) -> float:
+    metric = design["objectives"][objective]["components"][component]
+    return _finite_value(
+        metric, f"{design['name']} objective {objective} component {component}"
+    )
+
+
+def _case_parameters(case: Case, names: tuple[str, ...]) -> dict[str, float]:
+    metadata = case.read_metadata()
+    assert metadata is not None
+    suggestion = metadata["optimizer-suggestion"]
+    return {name: float(suggestion[name]["value"]) for name in names}
+
+
+def _param_delta(left: dict[str, float], right: dict[str, float]) -> float:
+    return sum(abs(left[name] - right[name]) for name in left)
+
+
+def _assert_campaign_outputs(
+    session_dir: Path, *, expected_count: int = MAX_EVALUATIONS
+) -> list[dict[str, Any]]:
+    designs = _load_designs(session_dir)
+    assert len(designs) == expected_count
+
+    for design in designs:
+        assert design["generation_index"] is not None
+        assert set(design["parameters"]) == {"alpha", "camber"}
+        score = design["objectives"]["aero_score"]
+        score_value = _objective_value(design, "aero_score")
+        assert 0.25 < score_value < 1.50
+        assert score["is_scalarized"] is True
+        assert score["component_bounds"] == {"drag": {"lte": 0.08}}
+        assert set(score["components"]) == {"lift", "drag"}
+        assert score["components"]["lift"]["minimize"] is False
+        assert score["components"]["drag"]["minimize"] is True
+        lift = _component_value(design, "aero_score", "lift")
+        drag = _component_value(design, "aero_score", "drag")
+        assert 0.30 < lift < 2.00
+        assert 0.00 < drag < 0.30
+        pressure = _constraint_value(design, "pressure_recovery")
+        stability = _constraint_value(design, "stability_margin")
+        assert -0.10 < pressure < 0.90
+        assert -0.10 < stability < 0.40
+        assert design["constraints"]["pressure_recovery"]["gte"] == 0.58
+        assert design["constraints"]["stability_margin"]["gte"] == 0.08
+
+    completed = session_dir / "cases_completed"
+    pending = session_dir / "cases_pending"
+    assert len([p for p in completed.iterdir() if p.is_dir()]) == len(designs)
+    assert [p for p in pending.iterdir() if p.is_dir()] == []
+
+    return designs
+
+
+def _assert_pareto_campaign_outputs(session_dir: Path) -> list[dict[str, Any]]:
+    designs = _load_designs(session_dir)
+    assert len(designs) == PARETO_MAX_EVALUATIONS
+
+    for design in designs:
+        assert design["generation_index"] is not None
+        assert set(design["parameters"]) == {"x", "y"}
+        assert set(design["objectives"]) == {"f_left", "f_right"}
+        assert design["objectives"]["f_left"]["minimize"] is True
+        assert design["objectives"]["f_right"]["minimize"] is True
+        f_left = _objective_value(design, "f_left")
+        f_right = _objective_value(design, "f_right")
+        stability = _constraint_value(design, "stability")
+        assert 0.00 <= f_left < 2.00
+        assert 0.00 <= f_right < 2.00
+        assert 0.00 <= stability <= 1.00
+        assert design["constraints"]["stability"]["gte"] == 0.85
+
+    completed = session_dir / "cases_completed"
+    pending = session_dir / "cases_pending"
+    assert len([p for p in completed.iterdir() if p.is_dir()]) == len(designs)
+    assert [p for p in pending.iterdir() if p.is_dir()] == []
+
+    return designs
+
+
+def _assert_design_sequences_match(
+    actual: list[dict[str, Any]],
+    expected: list[dict[str, Any]],
+) -> None:
+    assert len(actual) == len(expected)
+    for i, (actual_design, expected_design) in enumerate(zip(actual, expected)):
+        assert actual_design["generation_index"] == expected_design["generation_index"]
+        actual_params = _design_parameters([actual_design])[0]
+        expected_params = _design_parameters([expected_design])[0]
+        assert actual_params["alpha"] == pytest.approx(
+            expected_params["alpha"], abs=1e-6
+        ), f"alpha diverged at design {i}"
+        assert actual_params["camber"] == pytest.approx(
+            expected_params["camber"], abs=1e-6
+        ), f"camber diverged at design {i}"
+        assert _objective_value(actual_design, "aero_score") == pytest.approx(
+            _objective_value(expected_design, "aero_score"), abs=1e-6
+        ), f"aero_score diverged at design {i}"
+        assert _constraint_value(actual_design, "pressure_recovery") == pytest.approx(
+            _constraint_value(expected_design, "pressure_recovery"), abs=1e-6
+        ), f"pressure_recovery diverged at design {i}"
+        assert _constraint_value(actual_design, "stability_margin") == pytest.approx(
+            _constraint_value(expected_design, "stability_margin"), abs=1e-6
+        ), f"stability_margin diverged at design {i}"
+
+
+def _assert_sobol_prefix_matches(
+    actual: list[dict[str, Any]],
+    expected: list[dict[str, Any]],
+) -> None:
+    actual_params = _design_parameters(actual[:INITIALIZATION_TRIALS])
+    expected_params = _design_parameters(expected[:INITIALIZATION_TRIALS])
+    for i, (actual_param, expected_param) in enumerate(
+        zip(actual_params, expected_params)
+    ):
+        assert actual_param["alpha"] == pytest.approx(
+            expected_param["alpha"], abs=1e-9
+        ), f"Sobol alpha diverged at design {i}"
+        assert actual_param["camber"] == pytest.approx(
+            expected_param["camber"], abs=1e-9
+        ), f"Sobol camber diverged at design {i}"
+
+
+def _assert_xy_prefix_matches(
+    actual: list[dict[str, float]],
+    expected: list[dict[str, float]],
+    *,
+    n: int,
+) -> None:
+    assert len(actual) >= n
+    assert len(expected) >= n
+    for i, (actual_params, expected_params) in enumerate(zip(actual[:n], expected[:n])):
+        assert actual_params["x"] == pytest.approx(expected_params["x"], abs=1e-9), (
+            f"x diverged at Sobol design {i}"
+        )
+        assert actual_params["y"] == pytest.approx(expected_params["y"], abs=1e-9), (
+            f"y diverged at Sobol design {i}"
+        )
+
+
+def _submit_one_pending_bo_case(session: Session) -> tuple[str, dict[str, float]]:
+    # Drive exactly one optimizer cycle so the test can simulate a process
+    # dying after submission but before the next monitoring pass.
+    session._verify_search_space_in_template()
+
+    cases = session.loop_optimizer_once(num_new_cases=JOB_LIMIT)
+    assert len(cases) == JOB_LIMIT
+    case = cases[0]
+    params = _case_parameters(case, ("alpha", "camber"))
+
+    assert session.job_manager is not None
+    assert session.job_manager.submit_case(case)
+    session.persist()
+    return case.name, params
+
+
+def _run_uninterrupted_campaign(tmp_path: Path, monkeypatch) -> list[dict[str, Any]]:
+    _reset_session_case_ids(monkeypatch)
+    session_dir = tmp_path / "uninterrupted"
+    template = _create_synthetic_template(tmp_path / "template_a")
+    session = Session(
+        name="synthetic-airfoil-uninterrupted",
+        data_dir=session_dir,
+        clone_method="copy",
+        random_seed=RANDOM_SEED,
+        max_evaluations=MAX_EVALUATIONS,
+    )
+    _configure_synthetic_session(session, template)
+
+    session.start()
+
+    return _assert_campaign_outputs(session_dir)
+
+
+def _run_cold_first_suggestion(tmp_path: Path, monkeypatch) -> dict[str, float]:
+    _reset_session_case_ids(monkeypatch)
+    session_dir = tmp_path / "cold-start"
+    template = _create_synthetic_template(tmp_path / "template_cold")
+    session = Session(
+        name="synthetic-airfoil-cold-start",
+        data_dir=session_dir,
+        clone_method="copy",
+        random_seed=RANDOM_SEED,
+        max_evaluations=1,
+    )
+    _configure_synthetic_session(session, template)
+    session._verify_search_space_in_template()
+    session.backend.initialize()
+
+    cases = session.loop_optimizer_once(num_new_cases=1)
+    assert len(cases) == 1
+    return _case_parameters(cases[0], ("alpha", "camber"))
+
+
+def _run_pareto_campaign(
+    tmp_path: Path,
+    monkeypatch,
+    *,
+    subdir: str,
+    objective_variant: str,
+    max_evaluations: int = PARETO_MAX_EVALUATIONS,
+) -> list[dict[str, Any]]:
+    _reset_session_case_ids(monkeypatch)
+    session_dir = tmp_path / subdir
+    template = _create_pareto_ribbon_template(tmp_path / f"{subdir}_template")
+    session = Session(
+        name=f"synthetic-pareto-{subdir}",
+        data_dir=session_dir,
+        clone_method="copy",
+        random_seed=PARETO_SEED,
+        max_evaluations=max_evaluations,
+    )
+    _configure_pareto_session(
+        session,
+        template,
+        objective_variant=objective_variant,
+    )
+
+    session.start()
+
+    if max_evaluations == PARETO_MAX_EVALUATIONS:
+        return _assert_pareto_campaign_outputs(session_dir)
+    designs = _load_designs(session_dir)
+    assert len(designs) == max_evaluations
+    return designs
+
+
+def _run_restored_campaign(
+    tmp_path: Path, monkeypatch
+) -> tuple[list[dict[str, Any]], dict[str, float]]:
+    _reset_session_case_ids(monkeypatch)
+    session_dir = tmp_path / "restored"
+    template = _create_synthetic_template(tmp_path / "template_b")
+    session = Session(
+        name="synthetic-airfoil-restored",
+        data_dir=session_dir,
+        clone_method="copy",
+        random_seed=RANDOM_SEED,
+        max_evaluations=RESTORE_INTERRUPT_AFTER_COMPLETED,
+    )
+    _configure_synthetic_session(session, template)
+
+    # Finish the Sobol seed plus one BO trial, then interrupt with the next BO
+    # case pending. A cold restart from the same seed would now produce Sobol
+    # again, so this distinguishes continuation from accidental replay.
+    session.start()
+    before_interrupt = _assert_campaign_outputs(
+        session_dir, expected_count=RESTORE_INTERRUPT_AFTER_COMPLETED
+    )
+    assert before_interrupt[-1]["generation_index"] == "00005.01"
+
+    session.max_evaluations = MAX_EVALUATIONS
+    pending_bo_name, pending_bo_params = _submit_one_pending_bo_case(session)
+
+    restored = Session(name="ignored", data_dir=session_dir)
+    _configure_synthetic_session(restored)
+    restored.backend.initialize()
+    restored.persistent_optimization()
+
+    restored_designs = _assert_campaign_outputs(session_dir)
+    assert restored_designs[5]["name"] == pending_bo_name
+    assert (
+        _param_delta(_design_parameters([restored_designs[5]])[0], pending_bo_params)
+        < 1e-9
+    )
+    return restored_designs, pending_bo_params
+
+
+def test_synthetic_campaign_restores_pending_jobs_without_changing_designs(
+    tmp_path,
+    monkeypatch,
+):
+    try:
+        _install_synthetic_foam_dictionary(tmp_path, monkeypatch)
+        uninterrupted = _run_uninterrupted_campaign(tmp_path, monkeypatch)
+        restored, pending_bo_params = _run_restored_campaign(tmp_path, monkeypatch)
+        cold_start_params = _run_cold_first_suggestion(tmp_path, monkeypatch)
+    finally:
+        reset_runtime()
+
+    assert _param_delta(pending_bo_params, cold_start_params) > 1e-3, (
+        "The interrupted case matched a cold Sobol restart. The restore path "
+        "may have lost completed BO state instead of continuing the campaign."
+    )
+    _assert_sobol_prefix_matches(restored, uninterrupted)
+    _assert_design_sequences_match(restored, uninterrupted)
+
+
+def test_synthetic_pareto_ribbon_exercises_sobol_handoff_and_mobo_convergence(
+    tmp_path,
+    monkeypatch,
+):
+    try:
+        _install_synthetic_foam_dictionary(tmp_path, monkeypatch)
+        normal = _run_pareto_campaign(
+            tmp_path,
+            monkeypatch,
+            subdir="pareto-normal",
+            objective_variant="normal",
+        )
+        alternate = _run_pareto_campaign(
+            tmp_path,
+            monkeypatch,
+            subdir="pareto-alternate",
+            objective_variant="alternate",
+            max_evaluations=PARETO_INITIALIZATION_TRIALS + 1,
+        )
+    finally:
+        reset_runtime()
+
+    normal_params = _xy_parameters(normal)
+    alternate_params = _xy_parameters(alternate)
+
+    _assert_xy_prefix_matches(
+        normal_params,
+        alternate_params,
+        n=PARETO_INITIALIZATION_TRIALS,
+    )
+    first_bo_normal = normal_params[PARETO_INITIALIZATION_TRIALS]
+    first_bo_alternate = alternate_params[PARETO_INITIALIZATION_TRIALS]
+    first_bo_delta = abs(first_bo_normal["x"] - first_bo_alternate["x"]) + abs(
+        first_bo_normal["y"] - first_bo_alternate["y"]
+    )
+    assert first_bo_delta > 1e-3, (
+        "First post-Sobol suggestion did not change when objective observations "
+        "changed. That means the campaign may still be sampling instead of "
+        "using BO model state."
+    )
+
+    rounded_params = [
+        (round(params["x"], 12), round(params["y"], 12)) for params in normal_params
+    ]
+    assert len(rounded_params) == len(set(rounded_params))
+    assert len({design["name"] for design in normal}) == len(normal)
+    assert any(_constraint_value(design, "stability") >= 0.85 for design in normal)

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -10,7 +10,6 @@ def test_public_api():
 def test_submodule_imports():
     from flowboost.openfoam.case import Case  # noqa: F401
     from flowboost.openfoam.dictionary import Dictionary  # noqa: F401
-    from flowboost.optimizer.objectives import Objective, ScalarizedObjective  # noqa: F401
     from flowboost.optimizer.search_space import Dimension  # noqa: F401
     from flowboost.manager.manager import Manager  # noqa: F401
     from flowboost.session.session import Session  # noqa: F401

--- a/uv.lock
+++ b/uv.lock
@@ -905,7 +905,7 @@ wheels = [
 
 [[package]]
 name = "flowboost"
-version = "0.2.9"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "ax-platform", version = "1.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
Replaces the `set_outcome_constraints` string DSL with a proper `Constraint` primitive modeled as a peer of `Objective`. Constraint metrics register as tracking metrics on the Ax experiment before the `OutcomeConstraint` references them, so their values flow through `raw_data` alongside objectives and Ax never silently marks a trial failed for "missing required metric". Bounds are absolute; Ax's `OutcomeConstraint` defaults to relative, which would silently change the meaning of every `gte`/`lte` supplied.

Addresses #24. The pattern Bulut tried in the comment thread (register a metric as both an objective and a constraint via the string DSL) crashed Ax with "Cannot constrain on objective metric", and the alternative of referencing an unregistered metric name silently marked every trial failed. `Constraint` is the peer-of-`Objective` registration asked for in the thread.

Self-bounds on `Objective` (`Objective(..., lte=X)`) as sketched in #24 are a follow-up.

## Migration

```python
# Before: string DSL. Only worked if the constraint name was also a
# registered objective, which then triggered
# "Cannot constrain on objective metric".
session.backend.set_objectives([objective, Objective(name="pressure", ...)])
session.backend.set_outcome_constraints(["pressure >= 45.0"])

# After
pressure = Constraint(
    name="pressure", objective_function=read_pressure, gte=45.0,
)
session.backend.set_objectives([objective])
session.backend.set_constraints([pressure])
```

## Validation

`Constraint.__init__` rejects at construction:

- No bound (either `gte` or `lte` must be supplied)
- Inverted bounds (`gte > lte`)
- Single-point feasible range (`gte == lte`): meaningless for a soft outcome constraint on a continuous GP surrogate; use `gte=X-eps, lte=X+eps` for a tight tolerance
- Non-finite bounds (NaN, ±inf): use `None` for "no bound on this side"

`Backend.set_constraints` rejects at registration:

- Anything that is not a `Constraint` (an `Objective` smuggled in used to crash later with `AttributeError`; now rejects up front with a clear `TypeError`)

## Tests

Unit tests cover every validation branch. Three canaries drive real Ax end-to-end:

- `TestConstraintConvergenceCanary`: BO on a 2D quadratic with `x1 >= 2`; asserts best feasible point is near the constrained optimum.
- `TestMOOWithConstraint`: two `Objective`s in Pareto MOO mode plus one `Constraint`. Asserts BO explores both ends of the feasible Pareto front.
- `TestSessionLoopWithConstraint`: drives `Session.local_optimization` end-to-end with a real `AxBackend` and a `Constraint`, staging cases in the archival dir between cycles. Catches orchestration bugs in the `Case` metadata to `backend.tell` handoff.